### PR TITLE
Add owner-only terminal control and AI coding CLIs

### DIFF
--- a/controlplane/src/dashboards/handler.ts
+++ b/controlplane/src/dashboards/handler.ts
@@ -45,6 +45,8 @@ function formatSession(row: Record<string, unknown>) {
     id: row.id as string,
     dashboardId: row.dashboard_id as string,
     itemId: row.item_id as string,
+    ownerUserId: row.owner_user_id as string,
+    ownerName: row.owner_name as string,
     sandboxSessionId: row.sandbox_session_id as string,
     ptyId: row.pty_id as string,
     status: row.status as string,

--- a/controlplane/src/db/schema.ts
+++ b/controlplane/src/db/schema.ts
@@ -55,6 +55,8 @@ CREATE TABLE IF NOT EXISTS sessions (
   id TEXT PRIMARY KEY,
   dashboard_id TEXT NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
   item_id TEXT NOT NULL REFERENCES dashboard_items(id) ON DELETE CASCADE,
+  owner_user_id TEXT NOT NULL REFERENCES users(id),
+  owner_name TEXT NOT NULL DEFAULT '',
   sandbox_session_id TEXT NOT NULL,
   pty_id TEXT NOT NULL DEFAULT '',
   status TEXT NOT NULL CHECK (status IN ('creating', 'active', 'stopped', 'error')),

--- a/controlplane/src/types.ts
+++ b/controlplane/src/types.ts
@@ -85,6 +85,8 @@ export interface Session {
   id: string;
   dashboardId: string;
   itemId: string;        // The terminal item in the dashboard
+  ownerUserId: string;
+  ownerName: string;
   sandboxSessionId: string; // The session ID in the sandbox
   ptyId: string;         // The PTY ID in the sandbox session
   status: 'creating' | 'active' | 'stopped' | 'error';

--- a/controlplane/tests/helpers.ts
+++ b/controlplane/tests/helpers.ts
@@ -25,7 +25,9 @@ export async function createTestContext(): Promise<TestContext> {
     DASHBOARD: new MockDurableObjectNamespace(DashboardDO) as unknown as DurableObjectNamespace,
     SANDBOX_URL: 'http://localhost:8080',
     INTERNAL_API_TOKEN: 'test-internal-token',
+    SANDBOX_INTERNAL_TOKEN: 'test-sandbox-token',
     RATE_LIMITER: { limit: async () => ({ success: true }) },
+    DEV_AUTH_ENABLED: 'true',
   };
 
   return {
@@ -115,19 +117,27 @@ export async function seedSession(
   db: MockD1Database,
   dashboardId: string,
   itemId: string,
-  data: { id?: string; sandboxSessionId?: string; status?: string } = {}
+  data: {
+    id?: string;
+    sandboxSessionId?: string;
+    status?: string;
+    ownerUserId?: string;
+    ownerName?: string;
+  } = {}
 ) {
   const id = data.id || `session-${Date.now()}`;
   const sandboxSessionId = data.sandboxSessionId || `sandbox-${Date.now()}`;
   const status = data.status || 'active';
+  const ownerUserId = data.ownerUserId || 'owner-1';
+  const ownerName = data.ownerName || 'Owner';
   const now = new Date().toISOString();
 
   await db.prepare(`
-    INSERT INTO sessions (id, dashboard_id, item_id, sandbox_session_id, status, region, created_at)
-    VALUES (?, ?, ?, ?, ?, 'local', ?)
-  `).bind(id, dashboardId, itemId, sandboxSessionId, status, now).run();
+    INSERT INTO sessions (id, dashboard_id, item_id, owner_user_id, owner_name, sandbox_session_id, status, region, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, 'local', ?)
+  `).bind(id, dashboardId, itemId, ownerUserId, ownerName, sandboxSessionId, status, now).run();
 
-  return { id, dashboardId, itemId, sandboxSessionId, status };
+  return { id, dashboardId, itemId, ownerUserId, ownerName, sandboxSessionId, status };
 }
 
 export async function seedRecipe(

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This repository implements the **frontend experience layer** for a terminal-first, multiplayer agentic coding platform.
+This repository implements the **frontend experience layer** for a Agentic AI Coding Agent Orchestration figma like dashboard on the Web.
 
 It is responsible for:
 - authentication UI

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,10 +38,18 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.1.1",
+        "jsdom": "^27.4.0",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.0.16"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -62,6 +70,61 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -311,6 +374,141 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.25.tgz",
+      "integrity": "sha512-g0Kw9W3vjx5BEBAF8c5Fm2NcB/Fs8jJXh85aXqwEXiL+tqtOut07TWgyaGzAAfTM+gKckrrncyeGEZPcaRgm2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -930,6 +1128,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.8.0.tgz",
+      "integrity": "sha512-8JPn18Bcp8Uo1T82gR8lh2guEOa5KKU/IEKvvdp0sgmi7coPBWf1Doi1EXsGZb2ehc8ym/StJCjffYV+ne7sXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@exodus/crypto": "^1.0.0-rc.4"
+      },
+      "peerDependenciesMeta": {
+        "@exodus/crypto": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -4118,6 +4334,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4430,6 +4656,16 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4677,12 +4913,52 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -4803,6 +5079,20 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -4874,6 +5164,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -5006,6 +5303,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -6189,6 +6499,47 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6521,6 +6872,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6726,6 +7084,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -7182,6 +7580,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -7621,6 +8026,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8010,6 +8428,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -8184,6 +8612,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -8667,6 +9108,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
@@ -8742,6 +9190,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.19"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8753,6 +9221,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -9251,6 +9745,53 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9382,6 +9923,45 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xterm": {
       "version": "5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,8 +18,8 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.90.16",
-    "@xyflow/react": "^12.10.0",
     "@xterm/addon-fit": "^0.10.0",
+    "@xyflow/react": "^12.10.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",
@@ -43,6 +43,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
+    "jsdom": "^27.4.0",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.0.16"

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -74,7 +74,7 @@ export default function LoginPage() {
           </div>
           <h1 className="text-display text-[var(--foreground)] mb-2">OrcaBot</h1>
           <p className="text-body text-[var(--foreground-muted)]">
-            Terminal-first, multiplayer agentic coding
+            Agentic AI Coding Agent Orchestration on the Web
           </p>
         </div>
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -16,7 +16,7 @@ const jetbrainsMono = JetBrains_Mono({
 export const metadata: Metadata = {
   title: "OrcaBot - Agentic AI Coding Agent Orchestration on the Web",
   description:
-    "A collaborative workspace for terminal-first, multiplayer agentic coding.",
+    "A collaborative workspace for Agentic AI coding agent orchestration on the web.",
   icons: {
     icon: "/favicon.ico",
   },

--- a/frontend/src/components/blocks/TerminalBlock.test.tsx
+++ b/frontend/src/components/blocks/TerminalBlock.test.tsx
@@ -1,0 +1,126 @@
+import * as React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TerminalBlock } from "./TerminalBlock";
+import { useAuthStore } from "@/stores/auth-store";
+
+const useTerminalMock = vi.fn();
+
+vi.mock("@/hooks/useTerminal", () => ({
+  useTerminal: (...args: unknown[]) => useTerminalMock(...args),
+}));
+
+vi.mock("@/components/terminal", async () => {
+  const ReactModule = await vi.importActual<typeof import("react")>("react");
+  const Terminal = ReactModule.forwardRef((_props, ref) => {
+    ReactModule.useImperativeHandle(ref, () => ({
+      fit: vi.fn(),
+      write: vi.fn(),
+      getDimensions: () => ({ cols: 120, rows: 40 }),
+    }));
+    return <div data-testid="terminal" />;
+  });
+
+  return {
+    Terminal,
+    useTerminalOverlay: () => null,
+  };
+});
+
+vi.mock("./BlockWrapper", () => ({
+  BlockWrapper: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="block-wrapper">{children}</div>
+  ),
+}));
+
+function renderTerminal(sessionOwnerId: string, viewerId: string) {
+  const queryClient = new QueryClient();
+  useAuthStore.setState({
+    user: {
+      id: viewerId,
+      name: "Viewer",
+      email: "viewer@example.com",
+      createdAt: new Date().toISOString(),
+    },
+    isAuthenticated: true,
+    isLoading: false,
+  });
+
+  useTerminalMock.mockReturnValue([
+    {
+      connectionState: "connected",
+      turnTaking: {
+        controller: sessionOwnerId,
+        controllerName: "Owner",
+        isController: false,
+        hasPendingRequest: false,
+        pendingRequests: [],
+        inputBlocked: true,
+        inputBlockReason: "not_controller",
+      },
+      agentState: null,
+      error: null,
+    },
+    {
+      sendInput: vi.fn(),
+      sendRawInput: vi.fn(),
+      sendResize: vi.fn(),
+      takeControl: vi.fn(),
+      requestControl: vi.fn(),
+      grantControl: vi.fn(),
+      revokeControl: vi.fn(),
+      reconnect: vi.fn(),
+    },
+  ]);
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TerminalBlock
+        id="terminal-1"
+        data={{
+          content: "Terminal",
+          size: { width: 420, height: 320 },
+          dashboardId: "dashboard-1",
+          session: {
+            id: "session-1",
+            dashboardId: "dashboard-1",
+            itemId: "terminal-1",
+            ownerUserId: sessionOwnerId,
+            ownerName: "Owner",
+            sandboxSessionId: "sandbox-1",
+            ptyId: "pty-1",
+            status: "active",
+            region: "local",
+            createdAt: new Date().toISOString(),
+            stoppedAt: null,
+          },
+        }}
+        selected={false}
+        dragging={false}
+        positionAbsoluteX={0}
+        positionAbsoluteY={0}
+        width={420}
+        height={320}
+      />
+    </QueryClientProvider>
+  );
+}
+
+describe("TerminalBlock owner controls", () => {
+  beforeEach(() => {
+    useTerminalMock.mockReset();
+  });
+
+  it("shows control button for the owner", () => {
+    renderTerminal("owner-1", "owner-1");
+    expect(screen.getByText("Owner: Owner")).toBeTruthy();
+    expect(screen.getByText("Take Control")).toBeTruthy();
+  });
+
+  it("hides control button for non-owners", () => {
+    renderTerminal("owner-1", "viewer-1");
+    expect(screen.getAllByText("Owner: Owner").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Take Control")).toBeNull();
+  });
+});

--- a/frontend/src/components/blocks/TerminalBlock.tsx
+++ b/frontend/src/components/blocks/TerminalBlock.tsx
@@ -489,7 +489,8 @@ export function TerminalBlock({
   const isConnecting = connectionState === "connecting" || connectionState === "reconnecting";
   const isFailed = connectionState === "failed";
   const isAgentRunning = agentState === "running";
-  const canType = turnTaking.isController && !isAgentRunning && isConnected;
+  const isOwner = !!session && user?.id === session.ownerUserId;
+  const canType = isOwner && turnTaking.isController && !isAgentRunning && isConnected;
   const canInsertPrompt = canType;
 
   // Border color based on state
@@ -701,6 +702,7 @@ export function TerminalBlock({
 
   // Control handlers
   const handleRequestControl = () => {
+    if (!isOwner) return;
     terminalActions.requestControl();
   };
 
@@ -1117,14 +1119,16 @@ export function TerminalBlock({
         )}
 
         {/* Input blocked overlay (when connected but can't type) */}
-        {session && isConnected && !canType && (
+        {session && isConnected && !canType && isOwner && (
           <div className="absolute inset-0 bg-black/40 flex items-center justify-center">
             <div className="bg-[var(--background-elevated)] px-4 py-2 rounded-lg border border-[var(--border)] flex items-center gap-2">
               <Lock className="w-4 h-4 text-[var(--foreground-muted)]" />
               <span className="text-sm text-[var(--foreground-muted)]">
                 {isAgentRunning
                   ? "Agent is running"
-                  : "Click below to request control"}
+                  : isOwner
+                    ? "Click below to request control"
+                    : "View-only session"}
               </span>
             </div>
           </div>
@@ -1153,7 +1157,7 @@ export function TerminalBlock({
             </Button>
           )}
 
-          {session && isConnected && !turnTaking.isController && !isAgentRunning && (
+          {session && isConnected && !turnTaking.isController && !isAgentRunning && isOwner && (
             <Button
               variant="secondary"
               size="sm"
@@ -1174,53 +1178,61 @@ export function TerminalBlock({
           )}
         </div>
 
-        {/* Agent controls */}
-        {agentState !== "idle" && agentState !== null && (
-          <div className="flex items-center gap-1" style={{ pointerEvents: "auto" }}>
-            {isAgentRunning && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={handlePauseAgent}
-                  title="Pause agent"
-                  className="h-5 w-5"
-                >
-                  <Pause className="w-3 h-3" />
-                </Button>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  onClick={handleStopAgent}
-                  className="text-[10px] h-5 px-2"
-                >
-                  Stop
-                </Button>
-              </>
-            )}
-            {agentState === "paused" && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={handleResumeAgent}
-                  title="Resume agent"
-                  className="h-5 w-5"
-                >
-                  <Play className="w-3 h-3" />
-                </Button>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  onClick={handleStopAgent}
-                  className="text-[10px] h-5 px-2"
-                >
-                  Stop
-                </Button>
-              </>
-            )}
-          </div>
-        )}
+        <div className="flex items-center gap-2 text-[10px] text-[var(--foreground-subtle)]">
+          {session && (
+            <div>
+              Owner: {session.ownerName || "—"}
+            </div>
+          )}
+
+          {/* Agent controls */}
+          {agentState !== "idle" && agentState !== null && (
+            <div className="flex items-center gap-1" style={{ pointerEvents: "auto" }}>
+              {isAgentRunning && (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={handlePauseAgent}
+                    title="Pause agent"
+                    className="h-5 w-5"
+                  >
+                    <Pause className="w-3 h-3" />
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    onClick={handleStopAgent}
+                    className="text-[10px] h-5 px-2"
+                  >
+                    Stop
+                  </Button>
+                </>
+              )}
+              {agentState === "paused" && (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={handleResumeAgent}
+                    title="Resume agent"
+                    className="h-5 w-5"
+                  >
+                    <Play className="w-3 h-3" />
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    onClick={handleStopAgent}
+                    className="text-[10px] h-5 px-2"
+                  >
+                    Stop
+                  </Button>
+                </>
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -162,6 +162,8 @@ export interface Session {
   id: string;
   dashboardId: string;
   itemId: string;
+  ownerUserId: string;
+  ownerName: string;
   sandboxSessionId: string;
   ptyId: string; // PTY ID in the sandbox
   status: "creating" | "active" | "stopped" | "error";

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -18,7 +18,7 @@ test.describe("Authentication", () => {
     // Check for branding
     await expect(page.getByText("OrcaBot")).toBeVisible();
     await expect(
-      page.getByText("Terminal-first, multiplayer agentic coding")
+      page.getByText("Agentic AI Coding Agent Orchestration on the Web")
     ).toBeVisible();
 
     // Check for login options

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,7 +1,18 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "src"),
+    },
+  },
   test: {
+    environment: "jsdom",
     exclude: [
       "**/node_modules/**",
       "**/dist/**",

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     # Build essentials (needed for some npm packages)
     build-essential \
-    # Python (for Codex CLI)
+    # Python (useful for user scripts)
     python3 \
     python3-pip \
     python3-venv \
@@ -63,7 +63,14 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
 RUN npm install -g @anthropic-ai/claude-code
 
 # Install Codex CLI (OpenAI)
-RUN pip3 install --break-system-packages openai-codex-cli || true
+RUN npm install -g @openai/codex
+
+# Install Gemini CLI (Google)
+RUN npm install -g @google/gemini-cli
+
+# Install OpenCode CLI and move to shared location
+RUN curl -fsSL https://opencode.ai/install | bash \
+    && mv /root/.opencode/bin/opencode /usr/local/bin/opencode
 
 # Create workspace directory
 RUN mkdir -p /workspace && chmod 777 /workspace


### PR DESCRIPTION
Control plane:
- Sessions now store owner_user_id and owner_name
- PTY WebSocket only allows control for session owner
- File delete is owner-only (403 for non-owners)
- Updated schema, handlers, and types

Frontend:
- TerminalBlock enforces owner-only typing/control
- Shows owner name in terminal footer
- Non-owners see "view-only session" message
- Added jsdom for unit testing with vitest
- Updated branding text

Sandbox:
- Fixed Codex CLI install (npm instead of pip)
- Added Gemini CLI (@google/gemini-cli)
- Added OpenCode CLI (opencode.ai)