### PR TITLE
fix(security): change rate limiter to fail-closed behavior

### DIFF
--- a/controlplane/src/integration-policies/gateway.ts
+++ b/controlplane/src/integration-policies/gateway.ts
@@ -262,9 +262,9 @@ async function checkRateLimit(
     }));
 
     if (!res.ok) {
-      // Fail open on error
-      console.error(`[gateway] Rate limit check failed: ${res.status}`);
-      return { allowed: true };
+      // Fail closed on error - deny requests when rate limiter is unavailable
+      console.error(`[gateway] Rate limit check failed (failing closed): ${res.status}`);
+      return { allowed: false, reason: 'Rate limiter unavailable - request denied for safety' };
     }
 
     const result = await res.json() as { allowed: boolean; remaining?: number };
@@ -275,8 +275,9 @@ async function checkRateLimit(
       };
     }
   } catch (err) {
-    // Fail open on error
-    console.error(`[gateway] Rate limit check error:`, err);
+    // Fail closed on error - deny requests when rate limiter is unavailable
+    console.error(`[gateway] Rate limit check error (failing closed):`, err);
+    return { allowed: false, reason: 'Rate limiter unavailable - request denied for safety' };
   }
 
   return { allowed: true };

--- a/controlplane/src/integration-policies/handler.ts
+++ b/controlplane/src/integration-policies/handler.ts
@@ -184,9 +184,9 @@ async function checkRateLimit(
 
     return { allowed: true };
   } catch (e) {
-    // If rate limiting fails, allow the request (fail open for availability)
-    console.error('[rate-limit] Failed to check rate limit:', e);
-    return { allowed: true };
+    // If rate limiting fails, deny the request (fail closed for security)
+    console.error('[rate-limit] Failed to check rate limit (failing closed):', e);
+    return { allowed: false, reason: 'Rate limiter unavailable - request denied for safety' };
   }
 }
 


### PR DESCRIPTION
SECURITY FIX

Previously, rate limiting would allow requests to pass when the rate limiter Durable Object was unavailable or returned an error. This "fail-open" behavior could be exploited:

1. Attacker sends traffic to trigger rate limiter overload
2. Rate limiter becomes unavailable/times out
3. All subsequent requests bypass rate limiting
4. Attacker can exceed daily/hourly limits indefinitely

Changed to fail-closed behavior:
- Rate limiter errors now return { allowed: false }
- Requests are denied when rate limiter is unavailable
- Provides defense against DoS amplification attacks

Affected files:
- controlplane/src/integration-policies/gateway.ts
- controlplane/src/integration-policies/handler.ts