### PR TITLE
fix(memory): close orphaned WebSocket connections when hub is stopped

### DIFF
--- a/sandbox/internal/ws/router.go
+++ b/sandbox/internal/ws/router.go
@@ -119,7 +119,8 @@ func (r *Router) HandleWebSocket(w http.ResponseWriter, req *http.Request) {
 
 	client := NewClientWithUser(conn, ptyInfo.Hub, userID)
 	if client == nil {
-		// Hub already stopped
+		// Hub already stopped - close the orphaned connection to prevent leak
+		conn.Close()
 		return
 	}
 	go client.ReadPump()
@@ -151,7 +152,8 @@ func (r *Router) HandleAgentWebSocket(w http.ResponseWriter, req *http.Request) 
 
 	client := NewClientWithUser(conn, agent.Hub(), userID)
 	if client == nil {
-		// Hub already stopped
+		// Hub already stopped - close the orphaned connection to prevent leak
+		conn.Close()
 		return
 	}
 	go client.ReadPump()


### PR DESCRIPTION
BUG FIX

When a client connects via WebSocket and the Hub is already stopped, the connection was left open but unused, causing a memory leak.

Fixed in two places:
1. HandlePTYWebSocket - regular terminal connections
2. HandleAgentWebSocket - agent terminal connections

Now when NewClientWithUser returns nil (hub stopped), the WebSocket connection is explicitly closed to prevent:
- Orphaned connection accumulation
- Connection limit exhaustion
- Memory leaks