### PR TITLE
fix(security): sanitize gateway error messages, gate behind DEV_AUTH_ENABLED

### DIFF
--- a/controlplane/src/integration-policies/gateway.ts
+++ b/controlplane/src/integration-policies/gateway.ts
@@ -1,8 +1,8 @@
 // Copyright 2026 Robert Macrae. All rights reserved.
 // SPDX-License-Identifier: LicenseRef-Proprietary
 
-// REVISION: gateway-v11-clean-plaintext-urls
-console.log(`[integration-gateway] REVISION: gateway-v11-clean-plaintext-urls loaded at ${new Date().toISOString()}`);
+// REVISION: gateway-v11-sanitize-errors-devgate
+console.log(`[integration-gateway] REVISION: gateway-v11-sanitize-errors-devgate loaded at ${new Date().toISOString()}`);
 
 /**
  * Integration Policy Gateway Execute Handler
@@ -708,6 +708,11 @@ export async function handleGatewayExecute(
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : 'Unknown error';
 
+    // Log full error internally for debugging
+    console.error(`[gateway] API error for ${provider}/${body.action}:`, errorMessage);
+
+    const isDev = env.DEV_AUTH_ENABLED === 'true';
+
     await logAuditEntry(env, {
       terminalIntegrationId: ti.id,
       terminalId,
@@ -718,11 +723,13 @@ export async function handleGatewayExecute(
       policyId,
       policyVersion,
       decision: 'denied',
-      denialReason: `API error: ${errorMessage}`,
+      // In dev mode, keep full error for debugging; in prod, sanitize
+      denialReason: isDev ? `API error: ${errorMessage}` : `API error (see server logs for details)`,
     });
 
+    // In dev mode, return the full error for debugging; in prod, don't leak API details
     return Response.json(
-      { error: 'API_ERROR', reason: errorMessage },
+      { error: 'API_ERROR', reason: isDev ? errorMessage : 'Action failed - please try again or contact support' },
       { status: 502 }
     );
   }


### PR DESCRIPTION
In production (DEV_AUTH_ENABLED != 'true'), error messages are sanitized to prevent leaking API details, user emails, or URLs to the sandbox. In dev mode, full error messages are preserved for debugging.

- API errors return generic "Action failed" in prod, full message in dev
- Audit log stores full error in dev, reference to server logs in prod
- Full error always logged to console.error regardless of mode