### PR TITLE
fix(security): add iat validation to PTY token verification

### DIFF
--- a/controlplane/src/auth/pty-token.ts
+++ b/controlplane/src/auth/pty-token.ts
@@ -173,6 +173,14 @@ export async function verifyPtyToken(
       return null;
     }
 
+    // Check iat (issued-at) with clock skew tolerance
+    // Reject tokens issued too far in the future (clock skew attack prevention)
+    const CLOCK_SKEW_TOLERANCE = 60; // 60 seconds
+    if (payload.iat && payload.iat > now + CLOCK_SKEW_TOLERANCE) {
+      console.warn(`[pty-token] Rejecting token with future iat: ${payload.iat} > ${now + CLOCK_SKEW_TOLERANCE}`);
+      return null;
+    }
+
     return payload;
   } catch {
     return null;


### PR DESCRIPTION
SECURITY FIX

Added validation for the 'iat' (issued-at) field in PTY tokens:

- Reject tokens with iat more than 60 seconds in the future
- Prevents clock skew attacks where tokens appear valid before being issued
- Handles clock drift between control plane and sandbox gracefully
- Logs warning when rejecting future-dated tokens for debugging

Without this check, a token could be created with iat far in the future which could cause unexpected behavior in edge cases.