### PR TITLE
Add a network snitch and allowlist

### DIFF
--- a/controlplane/src/egress/handler.ts
+++ b/controlplane/src/egress/handler.ts
@@ -1,0 +1,363 @@
+// Copyright 2026 Rob Macrae. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+// REVISION: egress-handler-v5-pending-recovery-and-safe-revoke-rollback
+console.log(`[egress] REVISION: egress-handler-v5-pending-recovery-and-safe-revoke-rollback loaded at ${new Date().toISOString()}`);
+
+/**
+ * Egress Proxy Management
+ *
+ * Handles user approval flow for network egress:
+ * 1. User sees toast when unknown domain is held
+ * 2. User clicks Allow Once / Always Allow / Deny
+ * 3. Control plane stores "always" decisions in D1
+ * 4. Control plane forwards decision to sandbox proxy
+ *
+ * Also provides internal endpoints for sandbox to load persisted allowlist on startup.
+ */
+
+import type { Env } from '../types';
+import { sandboxHeaders, sandboxUrl } from '../sandbox/fetch';
+
+function generateId(): string {
+  return crypto.randomUUID().replace(/-/g, '');
+}
+
+function placeholders(count: number): string {
+  return new Array(count).fill('?').join(', ');
+}
+
+// ============================================
+// User-facing endpoints (authenticated)
+// ============================================
+
+/**
+ * POST /api/dashboards/:id/egress/approve
+ * User decision on a held egress connection.
+ */
+export async function handleApproveEgress(
+  request: Request,
+  env: Env,
+  dashboardId: string,
+  userId: string,
+): Promise<Response> {
+  const body = await request.json() as {
+    domain?: string;
+    decision?: string;
+    port?: number;
+    request_id?: string;
+  };
+
+  if (!body.domain || !body.decision) {
+    return Response.json({ error: 'E79870: domain and decision required' }, { status: 400 });
+  }
+  if (!body.request_id) {
+    return Response.json({ error: 'E79878: request_id required' }, { status: 400 });
+  }
+
+  const normalizedDomain = body.domain.trim().toLowerCase();
+
+  const validDecisions = ['allow_once', 'allow_always', 'deny'];
+  if (!validDecisions.includes(body.decision)) {
+    return Response.json({ error: 'E79871: invalid decision' }, { status: 400 });
+  }
+
+  // Forward decision to sandbox first. Persist only after sandbox accepts.
+  const sandbox = await env.DB.prepare(
+    `SELECT sandbox_session_id, sandbox_machine_id FROM dashboard_sandboxes WHERE dashboard_id = ?`
+  ).bind(dashboardId).first<{ sandbox_session_id: string; sandbox_machine_id: string }>();
+
+  if (!sandbox) {
+    return Response.json(
+      { error: 'E79879: no active sandbox to forward decision to' },
+      { status: 409 },
+    );
+  }
+
+  try {
+    const approveUrl = sandboxUrl(env, '/egress/approve');
+    const headers = sandboxHeaders(env, undefined, sandbox.sandbox_machine_id || undefined);
+    headers.set('Content-Type', 'application/json');
+
+    const resp = await fetch(approveUrl.toString(), {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        domain: normalizedDomain,
+        request_id: body.request_id,
+        decision: body.decision,
+      }),
+    });
+
+    if (!resp.ok) {
+      const errText = await resp.text().catch(() => '');
+      console.log(`[egress] Sandbox approve returned ${resp.status} for ${normalizedDomain}: ${errText}`);
+      return Response.json(
+        { error: `E79874: sandbox rejected decision (${resp.status})`, detail: errText },
+        { status: 502 },
+      );
+    }
+  } catch (err) {
+    console.log(`[egress] Failed to forward decision to sandbox: ${err}`);
+    return Response.json(
+      { error: `E79875: failed to reach sandbox`, detail: String(err) },
+      { status: 502 },
+    );
+  }
+
+  // If "always allow", persist to D1 only after sandbox accepted the decision.
+  if (body.decision === 'allow_always') {
+    const entryId = generateId();
+    await env.DB.prepare(`
+      INSERT INTO egress_allowlist (id, dashboard_id, domain, created_by, created_at)
+      SELECT ?, ?, ?, ?, datetime('now')
+      WHERE NOT EXISTS (
+        SELECT 1 FROM egress_allowlist
+        WHERE dashboard_id = ? AND domain = ? AND revoked_at IS NULL
+      )
+    `).bind(entryId, dashboardId, normalizedDomain, userId, dashboardId, normalizedDomain).run();
+  }
+
+  // Log the decision after successful sandbox forward.
+  const auditPort = body.port ?? 443;
+  const auditId = generateId();
+  await env.DB.prepare(`
+    INSERT INTO egress_audit_log (id, dashboard_id, domain, port, decision, decided_by, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+  `).bind(auditId, dashboardId, normalizedDomain, auditPort, body.decision, userId).run();
+
+  return Response.json({ ok: true });
+}
+
+/**
+ * GET /api/dashboards/:id/egress/allowlist
+ * List default + user-approved domains for a dashboard.
+ */
+export async function handleListEgressAllowlist(
+  request: Request,
+  env: Env,
+  dashboardId: string,
+): Promise<Response> {
+  const entries = await env.DB.prepare(`
+    SELECT id, domain, created_by, created_at
+    FROM egress_allowlist
+    WHERE dashboard_id = ? AND revoked_at IS NULL
+    ORDER BY created_at ASC
+  `).bind(dashboardId).all();
+
+  return Response.json({
+    entries: entries.results || [],
+  });
+}
+
+/**
+ * GET /api/dashboards/:id/egress/pending
+ * List currently pending egress approvals from the sandbox proxy.
+ */
+export async function handleListPendingEgress(
+  request: Request,
+  env: Env,
+  dashboardId: string,
+): Promise<Response> {
+  const sandbox = await env.DB.prepare(
+    `SELECT sandbox_machine_id FROM dashboard_sandboxes WHERE dashboard_id = ?`
+  ).bind(dashboardId).first<{ sandbox_machine_id: string }>();
+
+  if (!sandbox) {
+    return Response.json({ pending: [] });
+  }
+
+  try {
+    const pendingUrl = sandboxUrl(env, '/egress/pending');
+    const headers = sandboxHeaders(env, undefined, sandbox.sandbox_machine_id || undefined);
+    const resp = await fetch(pendingUrl.toString(), {
+      method: 'GET',
+      headers,
+    });
+    if (!resp.ok) {
+      const errText = await resp.text().catch(() => '');
+      console.log(`[egress] Sandbox pending returned ${resp.status}: ${errText}`);
+      return Response.json(
+        { error: `E79880: sandbox pending lookup failed (${resp.status})`, detail: errText },
+        { status: 502 },
+      );
+    }
+
+    const body = await resp.json() as { pending?: Array<{ domain: string; port: number; request_id: string }> };
+    return Response.json({ pending: body.pending || [] });
+  } catch (err) {
+    console.log(`[egress] Failed to fetch pending approvals from sandbox: ${err}`);
+    return Response.json(
+      { error: 'E79881: failed to reach sandbox pending endpoint', detail: String(err) },
+      { status: 502 },
+    );
+  }
+}
+
+/**
+ * DELETE /api/dashboards/:id/egress/allowlist/:entryId
+ * Revoke a user-approved domain.
+ */
+export async function handleRevokeEgressDomain(
+  request: Request,
+  env: Env,
+  dashboardId: string,
+  entryId: string,
+): Promise<Response> {
+  // Look up the domain before revoking so we can forward to sandbox
+  const entry = await env.DB.prepare(`
+    SELECT domain FROM egress_allowlist
+    WHERE id = ? AND dashboard_id = ? AND revoked_at IS NULL
+  `).bind(entryId, dashboardId).first<{ domain: string }>();
+
+  if (!entry) {
+    return Response.json({ error: 'E79872: entry not found' }, { status: 404 });
+  }
+
+  const activeRows = await env.DB.prepare(`
+    SELECT id FROM egress_allowlist
+    WHERE dashboard_id = ? AND domain = ? AND revoked_at IS NULL
+  `).bind(dashboardId, entry.domain).all<{ id: string }>();
+  const activeIds = (activeRows.results || []).map((row) => row.id);
+  if (activeIds.length === 0) {
+    return Response.json({ error: 'E79872: entry not found' }, { status: 404 });
+  }
+
+  const revokedAt = new Date().toISOString();
+  const idPlaceholders = placeholders(activeIds.length);
+
+  // Revoke all active rows for the same domain to clean up legacy duplicates.
+  await env.DB.prepare(`
+    UPDATE egress_allowlist
+    SET revoked_at = ?
+    WHERE id IN (${idPlaceholders}) AND revoked_at IS NULL
+  `).bind(revokedAt, ...activeIds).run();
+
+  // Forward revocation to sandbox so runtime allowlist is updated
+  const sandbox = await env.DB.prepare(
+    `SELECT sandbox_session_id, sandbox_machine_id FROM dashboard_sandboxes WHERE dashboard_id = ?`
+  ).bind(dashboardId).first<{ sandbox_session_id: string; sandbox_machine_id: string }>();
+
+  if (sandbox) {
+    try {
+      const revokeUrl = sandboxUrl(env, '/egress/revoke');
+      const headers = sandboxHeaders(env, undefined, sandbox.sandbox_machine_id || undefined);
+      headers.set('Content-Type', 'application/json');
+
+      const resp = await fetch(revokeUrl.toString(), {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ domain: entry.domain }),
+      });
+
+      if (!resp.ok) {
+        const errText = await resp.text().catch(() => '');
+        console.log(`[egress] Sandbox revoke returned ${resp.status} for ${entry.domain}: ${errText}`);
+        // Roll back D1 so state stays consistent
+        await env.DB.prepare(`
+          UPDATE egress_allowlist SET revoked_at = NULL
+          WHERE id IN (${idPlaceholders}) AND revoked_at = ?
+        `).bind(...activeIds, revokedAt).run();
+        return Response.json(
+          { error: `E79876: sandbox rejected revocation (${resp.status})`, detail: errText },
+          { status: 502 },
+        );
+      }
+    } catch (err) {
+      console.log(`[egress] Failed to forward revocation to sandbox: ${err}`);
+      // Roll back D1 so state stays consistent
+      await env.DB.prepare(`
+        UPDATE egress_allowlist SET revoked_at = NULL
+        WHERE id IN (${idPlaceholders}) AND revoked_at = ?
+      `).bind(...activeIds, revokedAt).run();
+      return Response.json(
+        { error: 'E79877: failed to reach sandbox', detail: String(err) },
+        { status: 502 },
+      );
+    }
+  }
+
+  return Response.json({ ok: true });
+}
+
+/**
+ * GET /api/dashboards/:id/egress/audit
+ * List recent egress audit log entries.
+ */
+export async function handleListEgressAudit(
+  request: Request,
+  env: Env,
+  dashboardId: string,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const limit = Math.min(parseInt(url.searchParams.get('limit') || '50'), 200);
+
+  const entries = await env.DB.prepare(`
+    SELECT id, domain, port, decision, decided_by, created_at
+    FROM egress_audit_log
+    WHERE dashboard_id = ?
+    ORDER BY created_at DESC
+    LIMIT ?
+  `).bind(dashboardId, limit).all();
+
+  return Response.json({
+    entries: entries.results || [],
+  });
+}
+
+// ============================================
+// Internal endpoints (sandbox → controlplane)
+// ============================================
+
+/**
+ * GET /internal/dashboards/:id/egress/allowlist
+ * Sandbox loads persisted allowlist on startup.
+ */
+export async function handleInternalGetAllowlist(
+  request: Request,
+  env: Env,
+  dashboardId: string,
+): Promise<Response> {
+  const entries = await env.DB.prepare(`
+    SELECT domain FROM egress_allowlist
+    WHERE dashboard_id = ? AND revoked_at IS NULL
+  `).bind(dashboardId).all<{ domain: string }>();
+
+  return Response.json({
+    domains: (entries.results || []).map(e => e.domain),
+  });
+}
+
+/**
+ * POST /internal/dashboards/:id/egress/audit
+ * Sandbox reports runtime egress decisions not captured by user actions.
+ */
+export async function handleInternalLogAudit(
+  request: Request,
+  env: Env,
+  dashboardId: string,
+): Promise<Response> {
+  const body = await request.json() as {
+    domain?: string;
+    port?: number;
+    decision?: string;
+    decided_by?: string | null;
+  };
+
+  const domain = body.domain?.trim().toLowerCase();
+  const port = Number.isInteger(body.port) ? body.port : 0;
+  const decision = body.decision?.trim();
+  const validDecisions = new Set(['allowed', 'denied', 'timeout', 'default_allowed', 'allow_once', 'allow_always', 'deny']);
+
+  if (!domain || !decision || !validDecisions.has(decision) || port <= 0 || port > 65535) {
+    return Response.json({ error: 'E79882: invalid audit payload' }, { status: 400 });
+  }
+
+  const auditId = generateId();
+  await env.DB.prepare(`
+    INSERT INTO egress_audit_log (id, dashboard_id, domain, port, decision, decided_by, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+  `).bind(auditId, dashboardId, domain, port, decision, body.decided_by ?? null).run();
+
+  return Response.json({ ok: true });
+}

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Keep dev/build type artifacts under the same dist dir to prevent
+  // next-env.d.ts from flipping between .next/dev and .next imports.
+  experimental: {
+    isolatedDevBuild: false,
+  },
   // Disable image optimization (not supported on Cloudflare Pages)
   images: {
     unoptimized: true,

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -75,6 +75,9 @@ export default function RootLayout({
                       document.documentElement.classList.add('dark');
                     }
                   }
+                  if (new URLSearchParams(window.location.search).get('egress') === '1') {
+                    localStorage.setItem('orcabot_egress_enabled', '1');
+                  }
                 } catch (e) {}
               })();
             `,

--- a/frontend/src/components/EgressAllowlistPanel.tsx
+++ b/frontend/src/components/EgressAllowlistPanel.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+// Copyright 2026 Rob Macrae. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+// REVISION: egress-allowlist-panel-v1
+const PANEL_REVISION = "egress-allowlist-panel-v1";
+console.log(`[EgressAllowlistPanel] REVISION: ${PANEL_REVISION} loaded at ${new Date().toISOString()}`);
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Shield, Trash2, Loader2, Globe } from "lucide-react";
+import { toast } from "sonner";
+import { listEgressAllowlist, revokeEgressDomain, type EgressAllowlistEntry } from "@/lib/api/cloudflare/egress";
+
+interface EgressAllowlistPanelProps {
+  dashboardId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function EgressAllowlistPanel({
+  dashboardId,
+  open,
+  onOpenChange,
+}: EgressAllowlistPanelProps) {
+  const [entries, setEntries] = useState<EgressAllowlistEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [revoking, setRevoking] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await listEgressAllowlist(dashboardId);
+      setEntries(result);
+    } catch {
+      // Keep current state on error
+    } finally {
+      setLoading(false);
+    }
+  }, [dashboardId]);
+
+  useEffect(() => {
+    if (open) {
+      void refresh();
+    }
+  }, [open, refresh]);
+
+  const handleRevoke = async (entry: EgressAllowlistEntry) => {
+    setRevoking(entry.id);
+    try {
+      await revokeEgressDomain(dashboardId, entry.id);
+      setEntries(prev => prev.filter(e => e.id !== entry.id));
+      toast.success(`Revoked: ${entry.domain}`);
+    } catch (err) {
+      toast.error(`Failed to revoke: ${err}`);
+    } finally {
+      setRevoking(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogTitle className="flex items-center gap-2">
+          <Shield className="w-5 h-5" />
+          Network Allowlist
+        </DialogTitle>
+
+        <div className="space-y-3">
+          <p className="text-xs text-muted-foreground">
+            Domains approved via &quot;Always Allow&quot;. Agents can connect to these without prompting.
+            Revoke to require approval again.
+          </p>
+
+          {loading ? (
+            <div className="flex items-center justify-center py-6">
+              <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+            </div>
+          ) : entries.length === 0 ? (
+            <div className="text-center py-6 text-sm text-muted-foreground">
+              No user-approved domains yet.
+            </div>
+          ) : (
+            <div className="space-y-1 max-h-64 overflow-y-auto">
+              {entries.map((entry) => (
+                <div
+                  key={entry.id}
+                  className="flex items-center justify-between gap-2 px-3 py-2 rounded-md bg-muted/50 border"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Globe className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
+                    <span className="font-mono text-xs truncate">{entry.domain}</span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => handleRevoke(entry)}
+                    disabled={revoking !== null}
+                    className="flex-shrink-0 text-muted-foreground hover:text-destructive"
+                  >
+                    {revoking === entry.id ? (
+                      <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                    ) : (
+                      <Trash2 className="w-3.5 h-3.5" />
+                    )}
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/EgressApprovalDialog.tsx
+++ b/frontend/src/components/EgressApprovalDialog.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+// Copyright 2026 Rob Macrae. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+// REVISION: egress-dialog-v3-request-id-resolution
+const EGRESS_DIALOG_REVISION = "egress-dialog-v3-request-id-resolution";
+console.log(`[EgressApprovalDialog] REVISION: ${EGRESS_DIALOG_REVISION} loaded at ${new Date().toISOString()}`);
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Shield, Globe, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+import { approveEgress, type EgressDecision } from "@/lib/api/cloudflare/egress";
+
+interface EgressApprovalRequest {
+  domain: string;
+  port: number;
+  request_id: string;
+}
+
+interface EgressApprovalDialogProps {
+  dashboardId: string;
+  pending: EgressApprovalRequest[];
+  onResolved: (requestId: string) => void;
+}
+
+export function EgressApprovalDialog({
+  dashboardId,
+  pending,
+  onResolved,
+}: EgressApprovalDialogProps) {
+  const [submitting, setSubmitting] = useState<string | null>(null);
+
+  const current = pending[0];
+  if (!current) return null;
+
+  const handleDecision = async (decision: EgressDecision) => {
+    setSubmitting(decision);
+    try {
+      await approveEgress(dashboardId, current.domain, decision, current.request_id, current.port);
+
+      const labels: Record<EgressDecision, string> = {
+        allow_once: "Allowed once",
+        allow_always: "Always allowed",
+        deny: "Denied",
+      };
+      toast.success(`${labels[decision]}: ${current.domain}`);
+      onResolved(current.request_id);
+    } catch (err) {
+      toast.error(`Failed to submit decision: ${err}`);
+    } finally {
+      setSubmitting(null);
+    }
+  };
+
+  return (
+    <Dialog open={pending.length > 0} onOpenChange={() => {}}>
+      <DialogContent className="sm:max-w-md" onPointerDownOutside={(e) => e.preventDefault()}>
+        <DialogTitle className="flex items-center gap-2">
+          <Shield className="w-5 h-5 text-yellow-500" />
+          Network Access Request
+        </DialogTitle>
+
+        <div className="space-y-4">
+          <div className="flex items-center gap-3 p-3 rounded-lg bg-muted/50 border">
+            <Globe className="w-8 h-8 text-muted-foreground flex-shrink-0" />
+            <div className="min-w-0">
+              <p className="font-mono text-sm font-medium truncate">{current.domain}</p>
+              <p className="text-xs text-muted-foreground">Port {current.port}</p>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+            <AlertTriangle className="w-4 h-4 text-yellow-500 flex-shrink-0 mt-0.5" />
+            <p className="text-xs text-muted-foreground">
+              An agent is trying to connect to this domain. The connection is held
+              until you approve or deny. If you don&apos;t respond within 60 seconds,
+              the connection will be denied automatically.
+            </p>
+          </div>
+
+          {pending.length > 1 && (
+            <p className="text-xs text-muted-foreground text-center">
+              +{pending.length - 1} more pending {pending.length - 1 === 1 ? "request" : "requests"}
+            </p>
+          )}
+
+          <div className="flex gap-2 justify-end">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => handleDecision("deny")}
+              disabled={submitting !== null}
+            >
+              Deny
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => handleDecision("allow_once")}
+              disabled={submitting !== null}
+            >
+              Allow Once
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => handleDecision("allow_always")}
+              disabled={submitting !== null}
+            >
+              Always Allow
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/blocks/TerminalBlock.tsx
+++ b/frontend/src/components/blocks/TerminalBlock.tsx
@@ -2048,7 +2048,9 @@ export function TerminalBlock({
 
     try {
       console.log(`[TerminalBlock] Creating session...`);
-      const newSession = await createSession(data.dashboardId, actualItemId);
+      const egressEnabled = localStorage.getItem("orcabot_egress_enabled") === "1"
+        || new URLSearchParams(window.location.search).get("egress") === "1";
+      const newSession = await createSession(data.dashboardId, actualItemId, egressEnabled ? { egressEnabled: true } : undefined);
       console.log(`[TerminalBlock] Session created:`, newSession);
       setSession(newSession);
       upsertDashboardSession(newSession);
@@ -2117,7 +2119,9 @@ export function TerminalBlock({
 
       // Create new session
       console.log(`[TerminalBlock] Creating new session...`);
-      const newSession = await createSession(data.dashboardId, actualItemId);
+      const egressEnabled = localStorage.getItem("orcabot_egress_enabled") === "1"
+        || new URLSearchParams(window.location.search).get("egress") === "1";
+      const newSession = await createSession(data.dashboardId, actualItemId, egressEnabled ? { egressEnabled: true } : undefined);
       console.log(`[TerminalBlock] New session created:`, newSession);
       setSession(newSession);
       upsertDashboardSession(newSession);

--- a/frontend/src/lib/api/cloudflare/dashboards.ts
+++ b/frontend/src/lib/api/cloudflare/dashboards.ts
@@ -211,10 +211,13 @@ export async function deleteItem(
  */
 export async function createSession(
   dashboardId: string,
-  itemId: string
+  itemId: string,
+  options?: { egressEnabled?: boolean }
 ): Promise<Session> {
+  const body = options?.egressEnabled ? { egress_enabled: true } : undefined;
   const response = await apiPost<SessionResponse>(
-    `${API.cloudflare.dashboards}/${dashboardId}/items/${itemId}/session`
+    `${API.cloudflare.dashboards}/${dashboardId}/items/${itemId}/session`,
+    body
   );
   return response.session;
 }

--- a/frontend/src/lib/api/cloudflare/egress.ts
+++ b/frontend/src/lib/api/cloudflare/egress.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 Rob Macrae. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+// REVISION: egress-api-v3-pending-approvals-fetch
+const MODULE_REVISION = "egress-api-v3-pending-approvals-fetch";
+console.log(`[egress-api] REVISION: ${MODULE_REVISION} loaded at ${new Date().toISOString()}`);
+
+import { API } from "@/config/env";
+import { apiGet, apiPost, apiDelete } from "../client";
+
+export type EgressDecision = 'allow_once' | 'allow_always' | 'deny';
+
+export interface EgressAllowlistEntry {
+  id: string;
+  domain: string;
+  created_by: string;
+  created_at: string;
+}
+
+export interface EgressAuditEntry {
+  id: string;
+  domain: string;
+  port: number;
+  decision: string;
+  decided_by: string;
+  created_at: string;
+}
+
+export interface PendingEgressApproval {
+  domain: string;
+  port: number;
+  request_id: string;
+}
+
+/**
+ * Approve or deny a held egress connection.
+ */
+export async function approveEgress(
+  dashboardId: string,
+  domain: string,
+  decision: EgressDecision,
+  requestId?: string,
+  port?: number,
+): Promise<void> {
+  console.log(`[egress-api] approveEgress called at ${new Date().toISOString()}`);
+  await apiPost(`${API.cloudflare.base}/dashboards/${dashboardId}/egress/approve`, {
+    domain,
+    decision,
+    port,
+    request_id: requestId,
+  });
+}
+
+/**
+ * List currently pending egress approvals for a dashboard.
+ */
+export async function listPendingEgressApprovals(
+  dashboardId: string,
+): Promise<PendingEgressApproval[]> {
+  console.log(`[egress-api] listPendingEgressApprovals called at ${new Date().toISOString()}`);
+  const response = await apiGet<{ pending: PendingEgressApproval[] }>(
+    `${API.cloudflare.base}/dashboards/${dashboardId}/egress/pending`
+  );
+  return response.pending || [];
+}
+
+/**
+ * List user-approved egress domains for a dashboard.
+ */
+export async function listEgressAllowlist(
+  dashboardId: string,
+): Promise<EgressAllowlistEntry[]> {
+  const response = await apiGet<{ entries: EgressAllowlistEntry[] }>(
+    `${API.cloudflare.base}/dashboards/${dashboardId}/egress/allowlist`
+  );
+  return response.entries || [];
+}
+
+/**
+ * Revoke a user-approved egress domain.
+ */
+export async function revokeEgressDomain(
+  dashboardId: string,
+  entryId: string,
+): Promise<void> {
+  await apiDelete(`${API.cloudflare.base}/dashboards/${dashboardId}/egress/allowlist/${entryId}`);
+}
+
+/**
+ * List recent egress audit log entries.
+ */
+export async function listEgressAudit(
+  dashboardId: string,
+  limit = 50,
+): Promise<EgressAuditEntry[]> {
+  const response = await apiGet<{ entries: EgressAuditEntry[] }>(
+    `${API.cloudflare.base}/dashboards/${dashboardId}/egress/audit?limit=${limit}`
+  );
+  return response.entries || [];
+}

--- a/frontend/src/lib/api/cloudflare/index.ts
+++ b/frontend/src/lib/api/cloudflare/index.ts
@@ -20,3 +20,4 @@ export * from "./bug-reports";
 export * from "./tasks";
 export * from "./chat";
 export * from "./dev";
+export * from "./egress";

--- a/frontend/src/lib/ws/TerminalWSManager.ts
+++ b/frontend/src/lib/ws/TerminalWSManager.ts
@@ -411,6 +411,14 @@ export class TerminalWSManager extends BaseWebSocketManager {
       case "tools_changed":
         this.notifyToolsChanged(message);
         break;
+
+      case "egress_approval_needed":
+      case "egress_approval_resolved":
+        // Egress events are dashboard-global (broadcast to all hubs).
+        // Dispatch as CustomEvent so the dashboard page can handle them
+        // without threading callbacks through Canvas/TerminalBlock.
+        window.dispatchEvent(new CustomEvent(message.type, { detail: message }));
+        break;
     }
   }
 

--- a/frontend/src/types/collaboration.ts
+++ b/frontend/src/types/collaboration.ts
@@ -257,6 +257,29 @@ export interface InboundMessageMessage {
 }
 
 /**
+ * Egress approval needed (server -> client via sandbox broadcast)
+ * Shown when the egress proxy holds a connection to an unknown domain.
+ */
+export interface EgressApprovalNeededMessage {
+  type: "egress_approval_needed";
+  domain: string;
+  port: number;
+  request_id: string;
+}
+
+/**
+ * Egress approval resolved (server -> client via sandbox broadcast)
+ * Sent when a held connection is approved or denied.
+ */
+export interface EgressApprovalResolvedMessage {
+  type: "egress_approval_resolved";
+  domain: string;
+  port: number;
+  request_id: string;
+  decision: string;
+}
+
+/**
  * All incoming collaboration messages
  */
 export type IncomingCollabMessage =
@@ -279,7 +302,9 @@ export type IncomingCollabMessage =
   | TaskUpdateMessage
   | TaskDeleteMessage
   | MemoryUpdateMessage
-  | InboundMessageMessage;
+  | InboundMessageMessage
+  | EgressApprovalNeededMessage
+  | EgressApprovalResolvedMessage;
 
 /**
  * All outgoing collaboration messages

--- a/frontend/src/types/terminal.ts
+++ b/frontend/src/types/terminal.ts
@@ -253,6 +253,30 @@ export interface ToolsChangedEvent {
 }
 
 /**
+ * Egress approval needed event (server -> client)
+ * Broadcast to all terminal WebSockets when the egress proxy holds
+ * a connection to an unknown domain pending user approval.
+ */
+export interface EgressApprovalNeededEvent {
+  type: "egress_approval_needed";
+  domain: string;
+  port: number;
+  request_id: string;
+}
+
+/**
+ * Egress approval resolved event (server -> client)
+ * Broadcast when a held connection is approved, denied, or times out.
+ */
+export interface EgressApprovalResolvedEvent {
+  type: "egress_approval_resolved";
+  domain: string;
+  port: number;
+  request_id: string;
+  decision: string;
+}
+
+/**
  * All incoming control events
  */
 export type IncomingControlEvent =
@@ -269,4 +293,6 @@ export type IncomingControlEvent =
   | TalkitoNoticeEvent
   | AgentStoppedEvent
   | CwdChangedEvent
-  | ToolsChangedEvent;
+  | ToolsChangedEvent
+  | EgressApprovalNeededEvent
+  | EgressApprovalResolvedEvent;

--- a/sandbox/internal/egress/allowlist.go
+++ b/sandbox/internal/egress/allowlist.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Rob Macrae. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+// REVISION: egress-allowlist-v3-chatgpt-localhost-bypass
+
+package egress
+
+import (
+	"log"
+	"strings"
+	"sync"
+	"time"
+)
+
+const allowlistRevision = "egress-allowlist-v3-chatgpt-localhost-bypass"
+
+func init() {
+	log.Printf("[egress-allowlist] REVISION: %s loaded at %s", allowlistRevision, time.Now().Format(time.RFC3339))
+}
+
+// Allowlist manages a thread-safe set of allowed domains with glob matching.
+// Default domains (package registries, git hosting, CDNs, LLM APIs) are always allowed.
+// User-approved domains can be added at runtime.
+type Allowlist struct {
+	mu       sync.RWMutex
+	defaults []string          // glob patterns (e.g., "*.github.com")
+	user     map[string]string // domain -> entryID (for revocation tracking)
+}
+
+// defaultDomains are always allowed without user approval.
+var defaultDomains = []string{
+	// Package registries
+	"registry.npmjs.org",
+	"pypi.org",
+	"files.pythonhosted.org",
+	"rubygems.org",
+	"proxy.golang.org",
+	"sum.golang.org",
+	"crates.io",
+	"static.crates.io",
+	"index.crates.io",
+	"registry.yarnpkg.com",
+	"repo.maven.apache.org",
+	"repo1.maven.org",
+	"plugins.gradle.org",
+	"services.gradle.org",
+	"*.gradle.org",
+	"central.sonatype.com",
+
+	// Git hosting
+	"github.com",
+	"*.github.com",
+	"*.githubusercontent.com",
+	"gitlab.com",
+	"*.gitlab.com",
+	"bitbucket.org",
+	"*.bitbucket.org",
+
+	// System packages
+	"deb.debian.org",
+	"*.debian.org",
+	"security.debian.org",
+	"archive.ubuntu.com",
+	"*.ubuntu.com",
+	"dl-cdn.alpinelinux.org",
+
+	// CDNs
+	"*.cloudflare.com",
+	"*.cloudfront.net",
+	"*.fastly.net",
+	"*.jsdelivr.net",
+	"*.unpkg.com",
+	"cdnjs.cloudflare.com",
+
+	// LLM APIs (already brokered, but allow direct too)
+	"api.anthropic.com",
+	"claude.ai",
+	"*.claude.ai",
+	"platform.claude.com",
+	"api.openai.com",
+	"chatgpt.com",
+	"*.chatgpt.com",
+	"*.googleapis.com",
+	"generativelanguage.googleapis.com",
+	"api.groq.com",
+	"api.together.xyz",
+	"api.fireworks.ai",
+	"api.mistral.ai",
+	"api.cohere.com",
+	"api-inference.huggingface.co",
+
+	// TTS providers
+	"api.elevenlabs.io",
+	"api.deepgram.com",
+
+	// Telemetry / monitoring (used by agents like Claude Code)
+	"*.datadoghq.com",
+	"*.datadoghq.eu",
+	"*.sentry.io",
+
+	// Common dev tools
+	"nodejs.org",
+	"*.nodejs.org",
+	"dl.google.com",
+	"storage.googleapis.com",
+	"objects.githubusercontent.com",
+}
+
+// NewAllowlist creates an Allowlist with default domains.
+func NewAllowlist() *Allowlist {
+	return &Allowlist{
+		defaults: append([]string{}, defaultDomains...),
+		user:     make(map[string]string),
+	}
+}
+
+// IsAllowed checks if a domain is permitted by the default or user allowlist.
+func (a *Allowlist) IsAllowed(domain string) bool {
+	domain = strings.ToLower(domain)
+
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	// Check defaults (glob patterns)
+	for _, pattern := range a.defaults {
+		if matchGlob(pattern, domain) {
+			return true
+		}
+	}
+
+	// Check user-approved domains (exact match)
+	if _, ok := a.user[domain]; ok {
+		return true
+	}
+
+	return false
+}
+
+// AddUserDomain adds a user-approved domain to the allowlist.
+func (a *Allowlist) AddUserDomain(domain, entryID string) {
+	domain = strings.ToLower(domain)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.user[domain] = entryID
+}
+
+// RemoveUserDomain removes a user-approved domain from the allowlist.
+func (a *Allowlist) RemoveUserDomain(domain string) {
+	domain = strings.ToLower(domain)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	delete(a.user, domain)
+}
+
+// UserDomains returns a copy of all user-approved domains.
+func (a *Allowlist) UserDomains() map[string]string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	result := make(map[string]string, len(a.user))
+	for k, v := range a.user {
+		result[k] = v
+	}
+	return result
+}
+
+// DefaultPatterns returns a copy of the default glob patterns.
+func (a *Allowlist) DefaultPatterns() []string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	result := make([]string, len(a.defaults))
+	copy(result, a.defaults)
+	return result
+}
+
+// matchGlob matches a domain against a glob pattern.
+// Supported syntax:
+//   - "*.example.com" matches "sub.example.com" and "a.b.example.com" but NOT "example.com"
+//   - "example.com" matches only "example.com" (exact match)
+func matchGlob(pattern, domain string) bool {
+	pattern = strings.ToLower(pattern)
+	domain = strings.ToLower(domain)
+
+	if pattern == domain {
+		return true
+	}
+
+	// Handle wildcard prefix: "*.example.com"
+	if strings.HasPrefix(pattern, "*.") {
+		suffix := pattern[1:] // ".example.com"
+		// domain must end with the suffix AND have at least one char before it
+		return strings.HasSuffix(domain, suffix) && len(domain) > len(suffix)
+	}
+
+	return false
+}

--- a/sandbox/internal/egress/allowlist_test.go
+++ b/sandbox/internal/egress/allowlist_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Rob Macrae. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+package egress
+
+import "testing"
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		pattern string
+		domain  string
+		want    bool
+	}{
+		// Exact match
+		{"example.com", "example.com", true},
+		{"example.com", "other.com", false},
+
+		// Wildcard prefix
+		{"*.example.com", "sub.example.com", true},
+		{"*.example.com", "a.b.example.com", true},
+		{"*.example.com", "example.com", false}, // wildcard requires at least one subdomain
+		{"*.example.com", "notexample.com", false},
+
+		// Case insensitivity
+		{"*.EXAMPLE.COM", "sub.example.com", true},
+		{"example.com", "EXAMPLE.COM", true},
+
+		// Real defaults
+		{"*.github.com", "raw.githubusercontent.com", false}, // different domain
+		{"*.github.com", "api.github.com", true},
+		{"*.github.com", "github.com", false},
+		{"github.com", "github.com", true},
+		{"*.googleapis.com", "storage.googleapis.com", true},
+		{"*.googleapis.com", "generativelanguage.googleapis.com", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.domain, func(t *testing.T) {
+			got := matchGlob(tt.pattern, tt.domain)
+			if got != tt.want {
+				t.Errorf("matchGlob(%q, %q) = %v, want %v", tt.pattern, tt.domain, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAllowlist_DefaultDomains(t *testing.T) {
+	al := NewAllowlist()
+
+	allowed := []string{
+		"registry.npmjs.org",
+		"pypi.org",
+		"github.com",
+		"api.github.com",
+		"raw.githubusercontent.com",
+		"api.anthropic.com",
+		"api.openai.com",
+		"storage.googleapis.com",
+		"deb.debian.org",
+		"cdnjs.cloudflare.com",
+		"index.crates.io",
+		"repo1.maven.org",
+		"plugins.gradle.org",
+	}
+
+	for _, domain := range allowed {
+		if !al.IsAllowed(domain) {
+			t.Errorf("Expected %q to be allowed (default)", domain)
+		}
+	}
+
+	blocked := []string{
+		"evil-site.com",
+		"exfiltrate-data.io",
+		"random-api.example.com",
+		"attacker.dev",
+	}
+
+	for _, domain := range blocked {
+		if al.IsAllowed(domain) {
+			t.Errorf("Expected %q to be blocked", domain)
+		}
+	}
+}
+
+func TestAllowlist_UserDomains(t *testing.T) {
+	al := NewAllowlist()
+
+	// Initially blocked
+	if al.IsAllowed("custom-api.example.com") {
+		t.Error("Expected custom-api.example.com to be blocked initially")
+	}
+
+	// Add user domain
+	al.AddUserDomain("custom-api.example.com", "entry-1")
+	if !al.IsAllowed("custom-api.example.com") {
+		t.Error("Expected custom-api.example.com to be allowed after adding")
+	}
+
+	// Case insensitive
+	if !al.IsAllowed("CUSTOM-API.EXAMPLE.COM") {
+		t.Error("Expected case-insensitive match for user domains")
+	}
+
+	// List user domains
+	domains := al.UserDomains()
+	if domains["custom-api.example.com"] != "entry-1" {
+		t.Error("Expected user domain to be in list")
+	}
+
+	// Remove user domain
+	al.RemoveUserDomain("custom-api.example.com")
+	if al.IsAllowed("custom-api.example.com") {
+		t.Error("Expected custom-api.example.com to be blocked after removal")
+	}
+}
+
+func TestAllowlist_DefaultPatterns(t *testing.T) {
+	al := NewAllowlist()
+	patterns := al.DefaultPatterns()
+
+	if len(patterns) == 0 {
+		t.Error("Expected non-empty default patterns")
+	}
+
+	// Verify it's a copy
+	patterns[0] = "modified"
+	origPatterns := al.DefaultPatterns()
+	if origPatterns[0] == "modified" {
+		t.Error("DefaultPatterns should return a copy")
+	}
+}

--- a/sandbox/internal/egress/proxy.go
+++ b/sandbox/internal/egress/proxy.go
@@ -1,0 +1,580 @@
+// Copyright 2026 Rob Macrae. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+// REVISION: egress-proxy-v5-localhost-bypass
+
+package egress
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Hyper-Int/OrcaBot/sandbox/internal/id"
+)
+
+const proxyRevision = "egress-proxy-v5-localhost-bypass"
+
+func init() {
+	log.Printf("[egress-proxy] REVISION: %s loaded at %s", proxyRevision, time.Now().Format(time.RFC3339))
+}
+
+const (
+	// ApprovalTimeout is how long to wait for user approval before denying.
+	ApprovalTimeout = 60 * time.Second
+
+	// DefaultPort is the default proxy listen port.
+	DefaultPort = 8083
+)
+
+// Decision values for approval responses.
+const (
+	DecisionAllowOnce   = "allow_once"
+	DecisionAllowAlways = "allow_always"
+	DecisionDeny        = "deny"
+	DecisionTimeout     = "timeout"
+	DecisionDefault     = "default_allowed"
+)
+
+// ApprovalRequest is sent when a connection to an unknown domain is held.
+type ApprovalRequest struct {
+	Domain    string `json:"domain"`
+	Port      int    `json:"port"`
+	RequestID string `json:"request_id"`
+}
+
+// ApprovalResolution is sent when a held connection is resolved (approve/deny/timeout).
+type ApprovalResolution struct {
+	Domain    string `json:"domain"`
+	Port      int    `json:"port"`
+	RequestID string `json:"request_id"`
+	Decision  string `json:"decision"`
+}
+
+// AuditEvent is emitted for runtime egress decisions to support audit logging.
+type AuditEvent struct {
+	Domain    string `json:"domain"`
+	Port      int    `json:"port"`
+	RequestID string `json:"request_id,omitempty"`
+	Decision  string `json:"decision"`
+}
+
+// Pending represents a held connection waiting for user approval.
+type Pending struct {
+	Domain    string
+	Port      int
+	RequestID string
+	decision  string        // set before closing doneCh
+	doneCh    chan struct{} // closed when decision is made
+	CreatedAt time.Time
+	Waiters   int // coalesced concurrent connections
+}
+
+// EgressProxy is an HTTP/HTTPS forward proxy that checks domains against
+// an allowlist and holds unknown connections until the user approves.
+type EgressProxy struct {
+	port             int
+	listener         net.Listener
+	server           *http.Server
+	allowlist        *Allowlist
+	pendingByID      map[string]*Pending // requestID -> pending approval
+	pendingByDomain  map[string]*Pending // domain -> pending approval
+	pendingMu        sync.Mutex
+	onApprovalNeeded func(req ApprovalRequest) // callback to broadcast WS event
+	onResolved       func(res ApprovalResolution)
+	onAuditEvent     func(event AuditEvent)
+	auditCh          chan AuditEvent      // buffered channel for async audit delivery
+	transport        *http.Transport      // shared transport for plain HTTP forwarding
+	stopCh           chan struct{}
+}
+
+const auditChannelSize = 256
+
+// NewEgressProxy creates a new egress proxy.
+func NewEgressProxy(port int, allowlist *Allowlist) *EgressProxy {
+	return &EgressProxy{
+		port:            port,
+		allowlist:       allowlist,
+		pendingByID:     make(map[string]*Pending),
+		pendingByDomain: make(map[string]*Pending),
+		auditCh:         make(chan AuditEvent, auditChannelSize),
+		transport:       &http.Transport{},
+		stopCh:          make(chan struct{}),
+	}
+}
+
+// Allowlist returns the proxy's allowlist for inspection.
+func (p *EgressProxy) Allowlist() *Allowlist {
+	return p.allowlist
+}
+
+// SetApprovalCallback sets the function called when a connection needs user approval.
+func (p *EgressProxy) SetApprovalCallback(fn func(req ApprovalRequest)) {
+	p.onApprovalNeeded = fn
+}
+
+// SetResolutionCallback sets the function called when an approval is resolved.
+func (p *EgressProxy) SetResolutionCallback(fn func(res ApprovalResolution)) {
+	p.onResolved = fn
+}
+
+// SetAuditCallback sets the function called when an egress decision should be audited.
+func (p *EgressProxy) SetAuditCallback(fn func(event AuditEvent)) {
+	p.onAuditEvent = fn
+}
+
+// Start begins listening and serving proxy requests.
+func (p *EgressProxy) Start() error {
+	addr := fmt.Sprintf("127.0.0.1:%d", p.port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("egress proxy listen: %w", err)
+	}
+	p.listener = ln
+
+	p.server = &http.Server{
+		Handler: p,
+	}
+
+	go func() {
+		log.Printf("[egress-proxy] Listening on %s", addr)
+		if err := p.server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			log.Printf("[egress-proxy] Server error: %v", err)
+		}
+	}()
+
+	// Background goroutine drains audit events so emitAudit never blocks
+	// the request path. Events are dropped if the channel is full.
+	go p.drainAuditEvents()
+
+	return nil
+}
+
+// Stop resolves all pending approvals as denied and shuts down the proxy.
+func (p *EgressProxy) Stop() {
+	close(p.stopCh)
+
+	// Deny all pending approvals
+	p.pendingMu.Lock()
+	for requestID, pending := range p.pendingByID {
+		log.Printf("[egress-proxy] Shutdown: denying pending approval for %s", pending.Domain)
+		pending.decision = DecisionDeny
+		close(pending.doneCh) // unblocks all waiters
+		delete(p.pendingByID, requestID)
+		delete(p.pendingByDomain, pending.Domain)
+	}
+	p.pendingMu.Unlock()
+
+	if p.server != nil {
+		p.server.Close()
+	}
+	if p.transport != nil {
+		p.transport.CloseIdleConnections()
+	}
+}
+
+// Resolve delivers a user decision for a pending approval by request ID.
+func (p *EgressProxy) Resolve(requestID, domain, decision string) bool {
+	requestID = strings.TrimSpace(requestID)
+	domain = strings.ToLower(domain)
+
+	p.pendingMu.Lock()
+	pending, ok := p.pendingByID[requestID]
+	if !ok {
+		p.pendingMu.Unlock()
+		return false
+	}
+	if domain != "" && domain != pending.Domain {
+		// Domain mismatch indicates stale/malformed client state.
+		p.pendingMu.Unlock()
+		return false
+	}
+	delete(p.pendingByID, requestID)
+	delete(p.pendingByDomain, pending.Domain)
+	p.pendingMu.Unlock()
+
+	// If always allow, add to allowlist
+	if decision == DecisionAllowAlways {
+		p.allowlist.AddUserDomain(pending.Domain, "runtime-"+pending.RequestID)
+	}
+
+	// Broadcast decision to all waiting goroutines
+	pending.decision = decision
+	close(pending.doneCh) // all waiters will read pending.decision
+	p.emitResolution(pending, decision)
+	// Note: no emitAudit here — user decisions (allow_once/always/deny) are logged
+	// by the control plane approve endpoint. Only default_allowed and timeout are
+	// forwarded via the audit channel.
+
+	log.Printf("[egress-proxy] Resolved %s (request_id=%s): %s (waiters: %d)", pending.Domain, pending.RequestID, decision, pending.Waiters)
+	return true
+}
+
+// PendingApprovals returns a list of currently pending domain approvals.
+func (p *EgressProxy) PendingApprovals() []ApprovalRequest {
+	p.pendingMu.Lock()
+	defer p.pendingMu.Unlock()
+
+	result := make([]ApprovalRequest, 0, len(p.pendingByID))
+	for _, pending := range p.pendingByID {
+		result = append(result, ApprovalRequest{
+			Domain:    pending.Domain,
+			Port:      pending.Port,
+			RequestID: pending.RequestID,
+		})
+	}
+	return result
+}
+
+// ServeHTTP handles proxy requests: CONNECT for HTTPS, regular for HTTP.
+func (p *EgressProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodConnect {
+		p.handleConnect(w, r)
+	} else {
+		p.handleHTTP(w, r)
+	}
+}
+
+// isLocalhost returns true for loopback addresses that should always bypass the proxy.
+func isLocalhost(host string) bool {
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+// handleConnect handles HTTPS CONNECT tunneling.
+func (p *EgressProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
+	host, port := splitHostPort(r.Host, 443)
+
+	// Localhost always bypasses — never hold or prompt for loopback traffic.
+	if isLocalhost(host) {
+		p.tunnelConnect(w, host, port)
+		return
+	}
+
+	if p.allowlist.IsAllowed(host) {
+		p.emitAudit(host, port, "", DecisionDefault)
+		p.tunnelConnect(w, host, port)
+		return
+	}
+
+	// Hold the connection and wait for approval
+	decision := p.holdForApproval(host, port)
+
+	switch decision {
+	case DecisionAllowOnce, DecisionAllowAlways:
+		p.tunnelConnect(w, host, port)
+	default:
+		// Deny: send 403 and close
+		http.Error(w, "Egress denied: domain not approved", http.StatusForbidden)
+	}
+}
+
+// handleHTTP handles plain HTTP proxy requests.
+func (p *EgressProxy) handleHTTP(w http.ResponseWriter, r *http.Request) {
+	targetURL, host, port, err := extractHTTPDestination(r)
+	if err != nil {
+		http.Error(w, "Bad proxy request", http.StatusBadRequest)
+		return
+	}
+
+	// Localhost always bypasses — never hold or prompt for loopback traffic.
+	if isLocalhost(host) {
+		// fall through to forward
+	} else if !p.allowlist.IsAllowed(host) {
+		decision := p.holdForApproval(host, port)
+		if decision != DecisionAllowOnce && decision != DecisionAllowAlways {
+			http.Error(w, "Egress denied: domain not approved", http.StatusForbidden)
+			return
+		}
+	} else {
+		p.emitAudit(host, port, "", DecisionDefault)
+	}
+
+	// Forward the request
+	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL.String(), r.Body)
+	if err != nil {
+		http.Error(w, "Bad request", http.StatusBadRequest)
+		return
+	}
+	outReq.Header = r.Header.Clone()
+	// Remove hop-by-hop headers
+	outReq.Header.Del("Proxy-Connection")
+	outReq.Header.Del("Proxy-Authorization")
+
+	resp, err := p.transport.RoundTrip(outReq)
+	if err != nil {
+		http.Error(w, "Upstream error", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy response headers
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}
+
+// holdForApproval blocks the current goroutine until the user approves/denies
+// or the timeout expires. Multiple connections to the same domain coalesce.
+func (p *EgressProxy) holdForApproval(domain string, port int) string {
+	domain = strings.ToLower(domain)
+
+	p.pendingMu.Lock()
+	if existing, ok := p.pendingByDomain[domain]; ok {
+		// Coalesce: another connection to the same domain is already pending
+		existing.Waiters++
+		p.pendingMu.Unlock()
+
+		return p.waitForDecision(existing)
+	}
+
+	// Create new pending entry
+	requestID, err := id.New()
+	if err != nil {
+		requestID = fmt.Sprintf("fallback-%d", time.Now().UnixNano())
+	}
+
+	pending := &Pending{
+		Domain:    domain,
+		Port:      port,
+		RequestID: requestID,
+		doneCh:    make(chan struct{}),
+		CreatedAt: time.Now(),
+		Waiters:   1,
+	}
+	p.pendingByID[requestID] = pending
+	p.pendingByDomain[domain] = pending
+	p.pendingMu.Unlock()
+
+	// Start timeout goroutine that cleans up the pending entry.
+	// This ensures timed-out entries don't stay in the map and block future connections.
+	go func() {
+		timer := time.NewTimer(ApprovalTimeout)
+		defer timer.Stop()
+		select {
+		case <-pending.doneCh:
+			// Resolved by user or shutdown — nothing to clean up
+		case <-timer.C:
+			var timedOut bool
+			p.pendingMu.Lock()
+			// Only clean up if this is still the same pending entry (not replaced)
+			if current, ok := p.pendingByID[pending.RequestID]; ok && current == pending {
+				delete(p.pendingByID, pending.RequestID)
+				delete(p.pendingByDomain, pending.Domain)
+				pending.decision = DecisionTimeout
+				close(pending.doneCh)
+				timedOut = true
+			}
+			p.pendingMu.Unlock()
+			// Emit callbacks outside the lock to avoid blocking pending operations
+			// on slow HTTP calls (forwardEgressAudit has a 5s timeout).
+			if timedOut {
+				p.emitResolution(pending, DecisionTimeout)
+				p.emitAudit(pending.Domain, pending.Port, pending.RequestID, DecisionTimeout)
+				log.Printf("[egress-proxy] Timeout: auto-denied %s (request_id=%s) and cleaned up pending entry", domain, pending.RequestID)
+			}
+		case <-p.stopCh:
+			// Proxy shutting down — Stop() handles cleanup
+		}
+	}()
+
+	// Notify frontend
+	if p.onApprovalNeeded != nil {
+		p.onApprovalNeeded(ApprovalRequest{
+			Domain:    domain,
+			Port:      port,
+			RequestID: requestID,
+		})
+	}
+
+	log.Printf("[egress-proxy] Holding connection to %s:%d (request_id=%s)", domain, port, requestID)
+
+	return p.waitForDecision(pending)
+}
+
+// waitForDecision blocks until a decision arrives or the proxy stops.
+// The timeout goroutine in holdForApproval handles expiry by closing doneCh.
+func (p *EgressProxy) waitForDecision(pending *Pending) string {
+	select {
+	case <-pending.doneCh:
+		if pending.decision == "" {
+			return DecisionDeny
+		}
+		return pending.decision
+	case <-p.stopCh:
+		return DecisionDeny
+	}
+}
+
+// tunnelConnect establishes a TCP tunnel for CONNECT requests.
+func (p *EgressProxy) tunnelConnect(w http.ResponseWriter, host string, port int) {
+	target := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+	upstream, err := net.DialTimeout("tcp", target, 10*time.Second)
+	if err != nil {
+		http.Error(w, "Cannot connect to upstream", http.StatusBadGateway)
+		return
+	}
+	defer upstream.Close()
+
+	// Hijack the client connection
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		http.Error(w, "Hijack failed", http.StatusInternalServerError)
+		return
+	}
+	defer clientConn.Close()
+
+	// Send 200 Connection Established
+	clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+
+	// Bidirectional relay
+	done := make(chan struct{}, 2)
+	go func() {
+		io.Copy(upstream, clientConn)
+		done <- struct{}{}
+	}()
+	go func() {
+		io.Copy(clientConn, upstream)
+		done <- struct{}{}
+	}()
+	<-done
+}
+
+// splitHostPort extracts host and port from a host:port string.
+// If no port is specified, defaultPort is used.
+func splitHostPort(hostport string, defaultPort int) (string, int) {
+	host, portStr, err := net.SplitHostPort(hostport)
+	if err != nil {
+		// No port specified
+		return strings.ToLower(hostport), defaultPort
+	}
+	port := defaultPort
+	if portStr != "" {
+		fmt.Sscanf(portStr, "%d", &port)
+	}
+	return strings.ToLower(host), port
+}
+
+func (p *EgressProxy) emitResolution(pending *Pending, decision string) {
+	if p.onResolved == nil || pending == nil {
+		return
+	}
+	p.onResolved(ApprovalResolution{
+		Domain:    pending.Domain,
+		Port:      pending.Port,
+		RequestID: pending.RequestID,
+		Decision:  decision,
+	})
+}
+
+// emitAudit enqueues an audit event for async delivery. Never blocks the caller;
+// drops the event if the channel is full (audit is best-effort telemetry).
+// Only runtime-only decisions (default_allowed, timeout) are enqueued; user
+// decisions (allow_once/always/deny) are logged by the control plane approve
+// endpoint and are filtered out here to avoid wasting channel capacity.
+func (p *EgressProxy) emitAudit(domain string, port int, requestID string, decision string) {
+	if decision != DecisionDefault && decision != DecisionTimeout {
+		return
+	}
+	event := AuditEvent{
+		Domain:    strings.ToLower(domain),
+		Port:      port,
+		RequestID: requestID,
+		Decision:  decision,
+	}
+	select {
+	case p.auditCh <- event:
+	default:
+		// Channel full — drop this event rather than block a proxy request.
+	}
+}
+
+// drainAuditEvents runs in a background goroutine, delivering queued audit
+// events to the callback. Exits when stopCh is closed and the channel is drained.
+func (p *EgressProxy) drainAuditEvents() {
+	for {
+		select {
+		case event := <-p.auditCh:
+			if p.onAuditEvent != nil {
+				p.onAuditEvent(event)
+			}
+		case <-p.stopCh:
+			// Drain remaining events before exiting.
+			for {
+				select {
+				case event := <-p.auditCh:
+					if p.onAuditEvent != nil {
+						p.onAuditEvent(event)
+					}
+				default:
+					return
+				}
+			}
+		}
+	}
+}
+
+func extractHTTPDestination(r *http.Request) (*url.URL, string, int, error) {
+	if r == nil || r.URL == nil {
+		return nil, "", 0, fmt.Errorf("missing URL")
+	}
+
+	targetURL := r.URL
+	if !targetURL.IsAbs() {
+		// Some clients send origin-form requests through a proxy.
+		host, port := splitHostPort(r.Host, 80)
+		if host == "" {
+			return nil, "", 0, fmt.Errorf("missing host")
+		}
+		hostPort := host
+		if port != 80 {
+			hostPort = net.JoinHostPort(host, strconv.Itoa(port))
+		}
+		targetURL = &url.URL{
+			Scheme:   "http",
+			Host:     hostPort,
+			Path:     r.URL.Path,
+			RawPath:  r.URL.RawPath,
+			RawQuery: r.URL.RawQuery,
+		}
+	}
+
+	targetHost := strings.ToLower(targetURL.Hostname())
+	if targetHost == "" {
+		return nil, "", 0, fmt.Errorf("missing target host")
+	}
+
+	targetPort := 80
+	if rawPort := targetURL.Port(); rawPort != "" {
+		parsedPort, err := strconv.Atoi(rawPort)
+		if err != nil || parsedPort <= 0 || parsedPort > 65535 {
+			return nil, "", 0, fmt.Errorf("invalid target port")
+		}
+		targetPort = parsedPort
+	}
+
+	if r.Host != "" {
+		claimedHost, _ := splitHostPort(r.Host, targetPort)
+		if claimedHost != "" && claimedHost != targetHost {
+			return nil, "", 0, fmt.Errorf("host mismatch")
+		}
+	}
+
+	return targetURL, targetHost, targetPort, nil
+}

--- a/sandbox/internal/egress/proxy_test.go
+++ b/sandbox/internal/egress/proxy_test.go
@@ -1,0 +1,263 @@
+// Copyright 2026 Rob Macrae. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+package egress
+
+import (
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSplitHostPort(t *testing.T) {
+	tests := []struct {
+		input       string
+		defaultPort int
+		wantHost    string
+		wantPort    int
+	}{
+		{"example.com:443", 80, "example.com", 443},
+		{"example.com:8080", 80, "example.com", 8080},
+		{"example.com", 443, "example.com", 443},
+		{"EXAMPLE.COM:443", 80, "example.com", 443},
+		{"sub.example.com:443", 80, "sub.example.com", 443},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			host, port := splitHostPort(tt.input, tt.defaultPort)
+			if host != tt.wantHost || port != tt.wantPort {
+				t.Errorf("splitHostPort(%q, %d) = (%q, %d), want (%q, %d)",
+					tt.input, tt.defaultPort, host, port, tt.wantHost, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestExtractHTTPDestination(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://registry.npmjs.org/express", nil)
+	req.Host = "registry.npmjs.org"
+
+	u, host, port, err := extractHTTPDestination(req)
+	if err != nil {
+		t.Fatalf("extractHTTPDestination returned error: %v", err)
+	}
+	if got := u.String(); got != "http://registry.npmjs.org/express" {
+		t.Fatalf("unexpected URL: %s", got)
+	}
+	if host != "registry.npmjs.org" || port != 80 {
+		t.Fatalf("unexpected host/port: %s:%d", host, port)
+	}
+}
+
+func TestExtractHTTPDestination_HostSpoofRejected(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://evil.example/path", nil)
+	req.Host = "registry.npmjs.org"
+
+	_, _, _, err := extractHTTPDestination(req)
+	if err == nil || !strings.Contains(err.Error(), "host mismatch") {
+		t.Fatalf("expected host mismatch error, got: %v", err)
+	}
+}
+
+func TestProxy_Resolve(t *testing.T) {
+	al := NewAllowlist()
+	proxy := NewEgressProxy(0, al)
+
+	// Simulate a pending approval
+	pending := &Pending{
+		Domain:    "unknown-api.com",
+		Port:      443,
+		RequestID: "test-req-1",
+		doneCh:    make(chan struct{}),
+		CreatedAt: time.Now(),
+		Waiters:   1,
+	}
+	proxy.pendingByID["test-req-1"] = pending
+	proxy.pendingByDomain["unknown-api.com"] = pending
+
+	// Resolve with allow_always
+	resolved := proxy.Resolve("test-req-1", "unknown-api.com", DecisionAllowAlways)
+	if !resolved {
+		t.Error("Expected Resolve to return true for pending domain")
+	}
+
+	// The domain should now be in the allowlist
+	if !al.IsAllowed("unknown-api.com") {
+		t.Error("Expected domain to be in allowlist after allow_always")
+	}
+
+	// Resolve non-existent domain
+	resolved = proxy.Resolve("not-pending", "not-pending.com", DecisionDeny)
+	if resolved {
+		t.Error("Expected Resolve to return false for non-pending domain")
+	}
+}
+
+func TestProxy_ResolveAllowOnce(t *testing.T) {
+	al := NewAllowlist()
+	proxy := NewEgressProxy(0, al)
+
+	pending := &Pending{
+		Domain:    "once-api.com",
+		Port:      443,
+		RequestID: "test-req-2",
+		doneCh:    make(chan struct{}),
+		CreatedAt: time.Now(),
+		Waiters:   1,
+	}
+	proxy.pendingByID["test-req-2"] = pending
+	proxy.pendingByDomain["once-api.com"] = pending
+
+	proxy.Resolve("test-req-2", "once-api.com", DecisionAllowOnce)
+
+	// allow_once should NOT add to allowlist
+	if al.IsAllowed("once-api.com") {
+		t.Error("Expected allow_once to NOT add domain to allowlist")
+	}
+}
+
+func TestProxy_PendingApprovals(t *testing.T) {
+	al := NewAllowlist()
+	proxy := NewEgressProxy(0, al)
+
+	// Empty initially
+	pending := proxy.PendingApprovals()
+	if len(pending) != 0 {
+		t.Errorf("Expected 0 pending, got %d", len(pending))
+	}
+
+	// Add some pending entries
+	proxy.pendingByID["r1"] = &Pending{
+		Domain:    "a.com",
+		Port:      443,
+		RequestID: "r1",
+		doneCh:    make(chan struct{}),
+		CreatedAt: time.Now(),
+		Waiters:   1,
+	}
+	proxy.pendingByID["r2"] = &Pending{
+		Domain:    "b.com",
+		Port:      80,
+		RequestID: "r2",
+		doneCh:    make(chan struct{}),
+		CreatedAt: time.Now(),
+		Waiters:   2,
+	}
+	proxy.pendingByDomain["a.com"] = proxy.pendingByID["r1"]
+	proxy.pendingByDomain["b.com"] = proxy.pendingByID["r2"]
+
+	pending = proxy.PendingApprovals()
+	if len(pending) != 2 {
+		t.Errorf("Expected 2 pending, got %d", len(pending))
+	}
+}
+
+func TestProxy_Coalescing(t *testing.T) {
+	al := NewAllowlist()
+	proxy := NewEgressProxy(0, al)
+
+	var callbackCount atomic.Int32
+	proxy.SetApprovalCallback(func(req ApprovalRequest) {
+		callbackCount.Add(1)
+	})
+
+	// Simulate multiple goroutines requesting the same domain
+	var wg sync.WaitGroup
+	decisions := make([]string, 3)
+
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			decisions[idx] = proxy.holdForApproval("coalesce-test.com", 443)
+		}(i)
+	}
+
+	// Give goroutines time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Only one callback should have fired
+	if got := callbackCount.Load(); got != 1 {
+		t.Errorf("Expected 1 callback, got %d", got)
+	}
+
+	// Check waiters count
+	proxy.pendingMu.Lock()
+	p := proxy.pendingByDomain["coalesce-test.com"]
+	if p != nil && p.Waiters != 3 {
+		t.Errorf("Expected 3 waiters, got %d", p.Waiters)
+	}
+	proxy.pendingMu.Unlock()
+
+	// Resolve
+	requestID := ""
+	proxy.pendingMu.Lock()
+	if p != nil {
+		requestID = p.RequestID
+	}
+	proxy.pendingMu.Unlock()
+	if requestID == "" {
+		t.Fatal("expected request ID for coalesced pending entry")
+	}
+	proxy.Resolve(requestID, "coalesce-test.com", DecisionAllowOnce)
+
+	wg.Wait()
+
+	// All should have received allow_once
+	for i, d := range decisions {
+		if d != DecisionAllowOnce {
+			t.Errorf("Decision[%d] = %q, want %q", i, d, DecisionAllowOnce)
+		}
+	}
+}
+
+func TestProxy_Stop(t *testing.T) {
+	al := NewAllowlist()
+	proxy := NewEgressProxy(0, al)
+
+	// Add pending entry
+	pending := &Pending{
+		Domain:    "stop-test.com",
+		Port:      443,
+		RequestID: "stop-req",
+		doneCh:    make(chan struct{}),
+		CreatedAt: time.Now(),
+		Waiters:   1,
+	}
+	proxy.pendingByID["stop-req"] = pending
+	proxy.pendingByDomain["stop-test.com"] = pending
+
+	// Stop should close all pending channels
+	proxy.Stop()
+
+	// Pending should be cleared
+	if len(proxy.pendingByID) != 0 || len(proxy.pendingByDomain) != 0 {
+		t.Errorf("Expected 0 pending after stop, got ids=%d domains=%d", len(proxy.pendingByID), len(proxy.pendingByDomain))
+	}
+}
+
+func TestProxy_CaseInsensitive(t *testing.T) {
+	al := NewAllowlist()
+	proxy := NewEgressProxy(0, al)
+
+	pending := &Pending{
+		Domain:    "mixed-case.com",
+		Port:      443,
+		RequestID: "case-req",
+		doneCh:    make(chan struct{}),
+		CreatedAt: time.Now(),
+		Waiters:   1,
+	}
+	proxy.pendingByID["case-req"] = pending
+	proxy.pendingByDomain["mixed-case.com"] = pending
+
+	// Resolve with different case
+	resolved := proxy.Resolve("case-req", "MIXED-CASE.COM", DecisionAllowAlways)
+	if !resolved {
+		t.Error("Expected case-insensitive resolve")
+	}
+}


### PR DESCRIPTION
Adds A transparent HTTP/HTTPS forward proxy on localhost:8083 that checks all sandbox egress against a glob-based allowlist of package registries, git hosts, CDNs, and LLM APIs, holds unknown connections until the user approves via a WebSocket-driven toast/dialog (with 60s fail-closed timeout, request coalescing, async audit logging, and always-allow persistence through the control plane), injected into PTY processes via HTTP_PROXY/HTTPS_PROXY env vars. 

Closes the raw HTTP exfiltration channel in Simon Willison's "lethal trifecta" (private data access + untrusted content + exfiltration) by requiring explicit user approval before any sandbox process can send workspace data to an unknown domain.