### PR TITLE
feat: custom model endpoints + OpenRouter routing polish

### DIFF
--- a/PLAN-custom-endpoints.md
+++ b/PLAN-custom-endpoints.md
@@ -1,0 +1,223 @@
+# PLAN: Custom / Self-Hosted Model Endpoints (Ollama, vLLM, cloud BYO)
+
+Status: Draft / design
+Author: (orcabot)
+Related: `frontend/src/data/openrouter-models.json`, `sandbox/internal/geminishim/`,
+`sandbox/internal/sessions/model_selection.go`, `PLAN-custom-secret-approval.md`,
+`PLAN-threat-detection.md`
+
+## 1. Summary
+
+Let users point any terminal at a **custom OpenAI-compatible model endpoint** — a local Ollama /
+LM Studio / llama.cpp / vLLM, or a self-hosted box on AWS / Together / Fireworks / Bedrock-via-gateway.
+Surface it as a "Custom endpoint" option in the Model panel, route it through the secrets broker
+(so any key is protected and egress is controlled), and make it work across **all harnesses**
+(Claude / Codex / OpenCode / Droid / Gemini) by **generalizing the existing `geminishim` into a
+universal translation gateway**.
+
+Key decisions:
+- **Default format = OpenAI-compatible chat completions** — the lingua franca of self-hosted
+  servers. Anthropic-compatible is an optional second format.
+- **Reuse the broker** custom-provider/custom-secret machinery for key injection + egress.
+- **One universal gateway** (the generalized shim) presents each harness its native wire format
+  and translates to chat-completions for the endpoint — this is the whole unlock, and it also
+  fixes Codex (which now requires the Responses API that self-hosted servers don't implement).
+
+## 2. Goals / Non-goals
+
+**Goals**
+- "Custom endpoint" in the Model panel: base URL + format + model + optional key + ctx/output limits.
+- Works for all harnesses against a plain OpenAI-compatible endpoint.
+- Desktop: auto-detect a local Ollama / LM Studio and wire the host-gateway address.
+- Cloud: user-provided URL, key protected by broker, endpoint domain allowed in egress.
+- Reusable per-user saved endpoints, selectable per terminal.
+
+**Non-goals**
+- Not shipping/curating local models — the user runs the server.
+- Not guaranteeing tool-calling/streaming quality on small local models (flag "experimental").
+- Not a generic reverse proxy for arbitrary protocols — OpenAI-compatible (+ optional Anthropic).
+
+## 3. Current state (what we build on)
+
+- **Model selection** (`model_selection.go`): `ModelSelection{Provider, Model, ContextWindow,
+  MaxOutputTokens}`. `applyOpenRouterEnv` wires per-harness env / CLI flags; OpenRouter routes
+  through the broker (`openrouter` / `openrouter-anthropic`). Limits flow FE→CP→sandbox.
+- **Translation proxy already exists** (`geminishim/`): accepts Gemini `generateContent`,
+  translates to OpenAI chat completions, forwards through the broker. This is ~80% of the
+  universal gateway — it already does format translation, SSE streaming, tool-call mapping,
+  schema sanitization, and broker forwarding.
+- **Broker custom secrets** (`secrets_broker.go`): `/broker/{sid}/custom/{secretName}?target=...`
+  with per-domain approval (`PLAN-custom-secret-approval.md`). The mechanism for "inject a key
+  for an arbitrary user-provided URL" already exists.
+- **Catalog UI** (`TerminalBlock.tsx` Model panel, `openrouter-models.json`): curated list +
+  `compatibleHarnesses` filtering + key-missing warnings.
+- **Passthrough** (`controlplane/src/sessions/handler.ts`, `sandbox/client.ts`,
+  `cmd/server/main.go`): `model_selection` provider/model + `contextWindow`/`maxOutputTokens`.
+
+## 4. The universal model gateway (generalize `geminishim`)
+
+Rename/extend `geminishim` → `modelgateway` (or keep the package, add formats). One localhost
+server per VM that **accepts a harness's native format and emits OpenAI chat-completions** to a
+configurable target (broker → custom endpoint, or broker → OpenRouter).
+
+Front-side translators (harness → chat-completions):
+- **Gemini** `generateContent` / `streamGenerateContent` — **exists**.
+- **Anthropic** `/v1/messages` — **new** (same shape as the Gemini translator; needed for Claude).
+- **OpenAI Responses** `/responses` — **new** (needed for Codex, which rejects `wire_api=chat`).
+- **OpenAI chat** `/chat/completions` — trivial pass-through (or skip the gateway entirely, below).
+
+Back-side: always POST chat-completions to the **broker custom-provider URL**, which injects the
+key (if any) and forwards to the user's endpoint. (Optionally a future Anthropic/Ollama-native
+back-side if a target needs it; OpenAI-chat covers Ollama/vLLM/etc.)
+
+The URL carries routing context, as the shim already does:
+`http://127.0.0.1:<gw>/cg/<sessionID>/<providerRef>/<base64(model)>/…`
+
+### Per-harness routing table (custom OpenAI-compatible endpoint)
+
+| Harness        | How it's pointed at the endpoint                                  | Gateway needed?               |
+|----------------|-------------------------------------------------------------------|-------------------------------|
+| OpenCode/Droid | `OPENAI_BASE_URL` = broker custom-provider URL, `OPENAI_MODEL`     | No — native chat-completions  |
+| Codex          | `-c` flags: `base_url` = gateway, `wire_api="responses"`           | **Yes** — Responses→chat      |
+| Claude         | `ANTHROPIC_BASE_URL` = gateway; placeholder `ANTHROPIC_API_KEY`    | **Yes** — Anthropic→chat      |
+| Gemini         | `GOOGLE_GEMINI_BASE_URL` = gateway (existing path)                 | **Yes** — Gemini→chat (exists)|
+
+OpenAI-native harnesses skip the gateway and hit the broker directly (least overhead). Everything
+else goes through the gateway. Mirrors the existing `applyOpenRouterEnv` switch — add a
+`provider == "custom"` branch alongside the OpenRouter one.
+
+## 5. Broker integration
+
+Add a **custom model provider** to the broker, generalizing the custom-secret flow:
+- Per-session config: `{ targetBaseURL, secretName?, headerName, headerFormat }`, installed when a
+  terminal with a custom endpoint is created (alongside the existing broker config push).
+- Route: `/broker/{sid}/customprovider/{providerRef}/...` → forwards to `targetBaseURL + path`,
+  injecting `Authorization: Bearer <key>` from the referenced user secret (or nothing for no-auth
+  local servers). Strips inbound auth (same as today).
+- Egress: the endpoint domain is **auto-approved** for the session (the user configured it) but
+  tagged a **data sink** for `PLAN-threat-detection.md`. No-auth localhost endpoints bypass.
+
+Key protection: the harness only ever sees the gateway/broker localhost URL + a placeholder key;
+the real key (if any) is injected server-side. Same guarantee as OpenRouter today.
+
+## 6. Data model & persistence
+
+New per-user table (reusable saved endpoints, like saved subagents):
+
+```
+user_model_providers(
+  id, user_id, label,
+  base_url,                 -- e.g. http://host.docker.internal:11434/v1  or  https://my-llm.aws…/v1
+  format,                   -- 'openai' | 'anthropic'   (default openai)
+  model_id,                 -- e.g. 'llama3.3:70b', 'qwen2.5-coder:32b'
+  secret_name,              -- nullable; ref to user_secrets for the API key
+  context_window,           -- manual (no catalog)
+  max_output_tokens,        -- manual
+  compatible_harnesses,     -- JSON array
+  is_local,                 -- hint: localhost/host-gateway vs public URL
+  created_at
+)
+```
+
+`ModelSelection` gains `provider: 'custom'` + `customProviderId` (and the resolved
+`baseUrl`/`format`/`model`/`contextWindow`/`maxOutputTokens`/`secretName` round-tripped
+FE→CP→sandbox, same path as the OpenRouter limits).
+
+## 7. UI (Model panel)
+
+A "Custom endpoint" section below Default/OpenRouter:
+- List of saved custom providers (per-user), each with label + model + a "local"/"remote" tag.
+- "+ Add custom endpoint" form: **label, base URL, format** (OpenAI default), **model id**,
+  **API key** (optional; stored as a brokered secret), **context window**, **max output tokens**,
+  **compatible harnesses**.
+- Same key-missing/validation affordances as the OpenRouter section, but scoped to the panel
+  (per the earlier fix — no badges leaking to the top-level menu).
+- For **remote** custom endpoints, a clear inline note: *"This endpoint receives the full
+  conversation context — only use providers you trust."* (security, §9).
+
+## 8. Desktop vs cloud
+
+**Desktop (Tauri, local VM sandbox)**
+- The user's Ollama/LM Studio runs on the **host**, not the sandbox. The Tauri layer
+  (`desktop/app/src-tauri`) should:
+  - **Auto-detect**: probe `http://localhost:11434/api/tags` (Ollama) and
+    `http://localhost:1234/v1/models` (LM Studio) on the host; offer found models in the panel.
+    For Ollama, **auto-fill the context window** from `/api/show` (`model_info`) so the user
+    doesn't have to guess; manual field with a default elsewhere.
+  - **Bridge networking**: inject the host-gateway address the sandbox can reach (e.g.
+    `host.docker.internal` on Docker Desktop, or the VM gateway IP) so a saved `base_url` of
+    `localhost:11434` is rewritten to the reachable host address for the sandbox.
+- No key, no public exposure, no egress concern (host-local). Best UX: "Found Ollama — pick a model."
+
+**Cloud (Fly sandbox)**
+- Endpoint must be reachable by URL (their AWS box, a tunnel like Cloudflare/ngrok, or a managed
+  BYO provider). Key held by broker; endpoint domain auto-allowed in egress (tagged data sink).
+- Surface the "receives full context" warning prominently here.
+
+## 9. Security considerations
+- **A custom endpoint receives the entire prompt context** — it is a user-authorized, full-data
+  egress channel. This is fine (it's their model) but must be explicit in the UI, and the endpoint
+  domain is a **data sink** for trifecta detection (`PLAN-threat-detection.md`) — a custom endpoint
+  is a *sanctioned* exfil-shaped channel, not a trusted one. Don't auto-suppress anomaly signals to it.
+- **Key protection** stays intact (broker injection); the LLM/harness never sees the real key.
+- **Egress** still applies: cloud endpoints are allowed because the user configured them, not
+  because they're safe. No-auth localhost (desktop host-gateway) bypasses egress like other loopback.
+- **No SSRF surprise**: the broker validates the target host against the configured custom-provider
+  base URL (same host-match guard the broker already enforces for built-in providers).
+
+## 10. Capability / limitations (be honest in UI)
+- **Codex** requires the Responses API surface — only works via the gateway's Responses→chat
+  translator; some advanced Codex features may degrade against a vanilla chat endpoint.
+- **Tool/function-calling + streaming** vary widely across self-hosted servers and small models;
+  tag custom endpoints "experimental." Schema sanitization (already in the shim) helps.
+- **Context window / max output** are user-supplied (no catalog) — wrong values degrade
+  compaction; show sensible defaults per known server where possible.
+- **Anthropic-format self-hosted servers are rare** — OpenAI-compatible is the real target.
+
+## 11. Phasing (status)
+
+1. **Universal gateway** — DONE. Generalized `geminishim`: `forwardChat(sessionID, provider, …)`
+   parameterizes the broker target; added Anthropic→chat (`anthropic.go`, `/av1`) and made the
+   Gemini `/gv1` path carry the provider. Responses→chat (Codex) still TODO.
+2. **Broker custom-provider** — DONE (folded into 3). The broker's built-in forwarding handles
+   `/broker/{sid}/customprovider/...` generically (target from config, SSRF host-match);
+   `GetCustomSecretValue` resolves the key; no-auth guard skips the auth header when keyless.
+3. **Data model + Model-panel UI** — DONE. `user_model_providers` table + CRUD; `ModelSelection`
+   `provider:'custom'` end-to-end (FE→CP→sandbox); Model-panel "Custom endpoint" section with
+   add-form (raw key auto-stored as a brokered secret) + full-context warning; `applyCustomEndpointEnv`
+   wires OpenCode/Droid (direct) + Claude (`/av1`) + Gemini (`/gv1`).
+4. **Desktop** — CORE DONE (testable): broker http-allowance for custom endpoints (gated on
+   `ALLOW_HTTP_CUSTOM_ENDPOINT`, SSRF host-match preserved) + `rewriteCustomBaseURLForDesktop`
+   (localhost → VM host gateway `10.0.2.2`, overridable via `ORCABOT_HOST_GATEWAY`). So a manually
+   added `http://localhost:11434/v1` routes to the host's Ollama on desktop.
+   REMAINING (needs the desktop env to test): the Tauri Ollama/LM Studio **auto-detect** UX (a
+   `detect_local_models` command + frontend pre-fill) — a convenience on top, not a blocker.
+   CAVEAT: only the QEMU/slirp VM backend has guest→host networking; the macOS native-VZ backend
+   does **not** (see `vm/macos.rs`), so local endpoints won't reach the host there.
+5. **Threat-detection integration** — BLOCKED on the threat-detection system itself
+   (`PLAN-threat-detection.md`), which is unbuilt. Note: brokered traffic bypasses egress (the
+   broker runs in the server process), so a custom endpoint never hits the egress allowlist — its
+   "data sink" nature only matters to the future threat-detection correlation. The user-facing
+   "this endpoint receives the full conversation context" warning is already in place. No code to
+   write here until threat-detection exists.
+
+Remaining work: Codex `Responses→chat` (Phase 1 follow-up) and the Tauri auto-detect UX (Phase 4).
+
+## 12. Resolved decisions (v1)
+1. **Scope: per-user** — saved endpoints belong to the user (same model as env vars / secrets),
+   reusable across dashboards. Team sharing deferred.
+2. **Explicit selection only** — a custom endpoint does NOT override the harness's "Default"
+   model; it appears as an explicit pick. (A custom *default* model is a later add-on.)
+3. **Desktop auto-detect = Ollama + LM Studio only** (`:11434` / `:1234`), plus manual add-by-URL
+   for anything else. No configurable probe list in v1.
+4. **Cloud = require a reachable URL** (user's own box/tunnel). No bundled tunnel helper in v1.
+5. **Auto-fill context window from Ollama** when detected (via its `model_info`/`/api/show`);
+   manual field with a sensible default elsewhere.
+
+## 13. Bottom line
+The `geminishim` we built for Gemini→OpenRouter is the same machine we need here — generalizing
+it to a universal translation gateway gives every harness access to any OpenAI-compatible endpoint,
+local or self-hosted, with the broker preserving key protection and egress control. Desktop gets a
+zero-config "we found your Ollama" path; cloud gets BYO-endpoint with an honest "this sees all your
+context" warning. The main new engineering is the Anthropic→chat and Responses→chat translators
+(Codex/Claude) and the per-user custom-provider plumbing.

--- a/PLAN-threat-detection.md
+++ b/PLAN-threat-detection.md
@@ -1,0 +1,221 @@
+# PLAN: Threat Detection (egress anomaly + inbound injection + trifecta correlation)
+
+Status: Draft / design
+Author: (orcabot)
+Related: `EGRESS_HARDENING.md`, `PLAN-secrets-protection.md`, `PLAN-integration-policy-enforcement.md`
+
+## 1. Summary & framing
+
+OrcaBot's current defenses (egress allowlist, secrets broker, integration-policy gateway)
+**prevent** the obvious and **fail-closed on the unknown**, but they cannot prevent a
+determined exfiltration through *allowed* channels, and they don't detect prompt-injection
+attacks arriving via inbound messages. This plan adds a **detection + notification + adaptive
+response** layer — explicitly *not* prevention.
+
+The model is a fraud-detection desk, not a firewall: we can't stop every attack, but we can
+catch a meaningful class, **tell the user and the admin it's happening**, and **automatically
+tighten the blast radius** when it does. The highest-value signal is the **lethal trifecta**
+lining up in one session: untrusted input ingested **+** access to private/sensitive data **+**
+an outbound exfiltration attempt.
+
+Three components, each independently useful, strongest when joined:
+
+1. **Egress anomaly detection** — "shapes in the network": volume/rate/fan-out/provenance.
+2. **Inbound prompt-injection scanner** — scan untrusted content before it reaches the LLM.
+3. **Provenance / trifecta correlation** — join #1 and #2 into a per-session risk verdict.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Detect bulk and patterned exfiltration to *allowed* domains and surface it to user + admin.
+- Detect likely prompt-injection in inbound messages/emails before delivery to the agent.
+- Give the admin a feedback loop: observability + the ability to tighten a channel/session.
+- Auto-downgrade blast radius on high-confidence detection (held-approval, pause, repliesOnly).
+- Reuse existing pipelines (egress audit, messaging webhook, WS→toast) — minimal new surface.
+
+**Non-goals / explicit non-guarantees**
+- NOT prevention. A competent attacker with prompt-injection can still exfiltrate via
+  low-bandwidth side channels (timing/ordering, `allowed.site/0` vs `/1`) — information-theoretically
+  invisible to traffic-shape heuristics. We say so in the UI; we do not claim coverage.
+- NOT a replacement for the allowlist/broker/policy layers — this is defense-in-depth on top.
+- The injection classifier is best-effort and adversaries adapt; false positives are expected.
+
+## 3. Current state (what we build on)
+
+- **Egress proxy** (`sandbox/internal/egress/proxy.go`): per-decision `AuditEvent{domain, port,
+  decision}` via `emitAudit` → control plane (`egress_audit_log` in `controlplane/src/egress/handler.ts`).
+  `tunnelConnect` already does the bidirectional `io.Copy` where bytes can be counted.
+  Gaps today: binary per-domain allow; no bytes/rate/path signal; wildcard sinks
+  (`*.sentry.io`, `*.datadoghq.com`, `*.cloudfront.net`, `storage.googleapis.com`) are open.
+- **Inbound messaging** (`controlplane/src/messaging/webhook-handler.ts`): verify sig → normalize →
+  load subscription+policy → enforce inbound policy (channel/sender/`repliesOnly`) → buffer in
+  `inbound_messages` → broadcast via DO + deliver/wake. **No content risk scan today.**
+- **Integration gateway** (`controlplane/src/integration-policies/`): `enforcePolicy` (boolean),
+  `filterResponse` (repo/sender filtering), per-action rate limits, audit. Email/message bodies
+  fetched for the LLM (`gmail.get`, etc.) are *not* injection-scanned.
+- **Alert pipeline (reuse)**: broker `model_provider_error` → `broadcastToSessionHubs` →
+  `model_provider_error` WS event → `TerminalWSManager` CustomEvent → `dashboards/[id]/page.tsx`
+  toast. This is the template for surfacing threat alerts.
+- **Admin** (`controlplane/src/analytics/handler.ts`, `GET /admin/metrics`, `frontend .../admin`).
+
+## 4. Architecture overview
+
+```
+Inbound (email/SMS/Slack/…)                      Outbound (agent → network)
+        │                                                 │
+        ▼                                                 ▼
+ webhook-handler / gateway read            egress proxy (sandbox)  +  integration gateway
+        │  normalize                         │  per-request audit + bytes/rate
+        ▼                                     ▼
+ [INJECTION SCANNER] ── risk ──┐     [EGRESS AGGREGATOR] ── anomaly ──┐
+        │                       │            │                         │
+   inbound_messages.risk        └──►  SESSION RISK STATE  ◄────────────┘
+        │                              (trifecta correlation)
+        ▼                                     │
+   quarantine? deliver?                       ▼
+        └──────────────►  NOTIFY (user toast + admin)  +  ADAPT (downgrade policy / pause)
+```
+
+Session risk state is the join point: a control-plane object keyed by `session_id` /
+`dashboard_id` accumulating (a) untrusted-input events, (b) sensitive-data-access events,
+(c) outbound-anomaly events. When enough align → escalate.
+
+## 5. Component 1 — Egress anomaly detection
+
+### Captured signals (extend the proxy, cheap, no MITM)
+- **Bytes out** per (session, domain): count in `tunnelConnect`'s client→upstream `io.Copy`
+  (wrap the copy or use a counting `io.Writer`). Add `BytesOut` to `AuditEvent`.
+- **Request/connection rate** per (session, domain): already one audit event per CONNECT/HTTP.
+- **Connection cardinality / fan-out**: distinct (domain, port) and distinct CONNECTs per domain
+  per window — proxy can't read TLS paths, but high connection cardinality to a wildcard sink is
+  itself the signal for the `/0`,`/1` pattern.
+- **Sink classification**: tag domains that are data-ingest capable (telemetry: `*.sentry.io`,
+  `*.datadoghq.com`; storage: `storage.googleapis.com`, `*.amazonaws.com`; paste/CDN-upload).
+  A static list in `defaults.json` (`"category": "data_sink"`) is enough to start.
+
+### Detection (control plane, aggregating `egress_audit_log`)
+Rolling per-session counters (Durable Object or D1 window query). Initial heuristics:
+- `bytes_out_to_sink_per_session > THRESHOLD` (e.g. 1 MB) → **medium**; > 10 MB → **high**.
+- `requests_per_min_to_domain > N` (e.g. 120) → **medium**.
+- `distinct_subpaths_or_connections_to_sink > K` in a short window → **medium** (side-channel shape).
+- **Provenance multiplier**: any of the above within T seconds of an untrusted-input or
+  sensitive-data event (from session risk state) → escalate one level.
+
+### Response
+- Emit a `threat_alert` WS event (reuse `broadcastToSessionHubs`) → dashboard toast:
+  *"Unusual egress: 4.2 MB sent to telemetry sink `*.sentry.io` in 30s."*
+- Write an `threat_events` row (audit) + admin notification.
+- **Adapt** (configurable, default on for `high`): flip the session's data-sink domains back to
+  held-approval (remove from runtime allowlist via `allowlist` API), and/or pause the agent.
+
+## 6. Component 2 — Inbound prompt-injection scanner
+
+### Hook points (the chokepoints where untrusted content enters)
+- `webhook-handler.ts` between **normalize** and **buffer/deliver** (step 5–6) — scan
+  `NormalizedMessage.text` for every inbound platform message.
+- Integration gateway read responses that return externally-authored content to the LLM
+  (`gmail.get/search`, future web fetch) — scan body before `filterResponse` returns it.
+
+### Two-stage classifier (cost/latency-aware)
+1. **Cheap pre-filter** (no model call): regex/heuristics — instruction-shaped text in a data
+   field ("ignore previous", "system:", "you are now"), tool-name lures, base64/hex blobs over a
+   length, suspicious URL shapes, zero-width/unicode obfuscation. Benign messages stop here.
+2. **LLM judge** (escalation only): a small fast model (Haiku) scoring injection likelihood +
+   category (instruction-override / exfil-request / tool-lure / encoded-payload). Returns
+   `{risk: 0–1, category, rationale}`.
+
+### Schema & handling
+- Add to `inbound_messages`: `risk_score REAL`, `risk_category TEXT`, `risk_status TEXT`
+  (`clear` | `flagged` | `quarantined`).
+- `risk >= QUARANTINE_THRESHOLD` → buffer but **do not auto-deliver**; require user confirm in UI.
+  Mark the message "⚠ possible injection" in the messaging block + inbound list.
+- Below quarantine but flagged → deliver but tag, and record for the channel's running score.
+
+### Adapt
+- A channel/sender with repeated flags auto-tightens: drop to `repliesOnly`, read-only, or
+  require approval for any tool call within N minutes of a flagged message. Surface to admin to
+  confirm/tune. (Adjust-settings-to-reduce-impact, the "bank" move.)
+
+## 7. Component 3 — Provenance / trifecta correlation
+
+A per-session **risk state** (Durable Object keyed by `session_id`) accumulates:
+- `untrusted_input` events (inbound message delivered, web/email content fetched).
+- `sensitive_access` events (integration gateway returned private data; secret broker used).
+- `outbound_anomaly` events (Component 1).
+
+Escalation rule (boolean, no LLM in the loop — auditable): when **all three** classes are present
+within a sliding window → **session under likely attack** → strongest response (pause agent,
+freeze data-sink egress, alert user + admin with the correlated timeline:
+*"message X → read of private data Y → 4 MB to sink Z"*). This is the single most valuable signal
+and the cleanest story to show a user.
+
+## 8. Cross-cutting
+
+### Notifications
+- **User**: `threat_alert` WS event → toast (reuse Component built for `model_provider_error`),
+  severity-styled, with the timeline and the action taken ("egress to sinks paused").
+- **Admin**: new `threat_events` feed on the admin page; optional email (Resend) for `high`.
+
+### Admin dashboard (extend `/admin/metrics` + page)
+- Threat events over time, by channel/provider/severity; top flagged senders/channels;
+  quarantine queue; per-dashboard "tightened" state.
+
+### Policy auto-adaptation
+- All adaptations are reversible and logged; admin can pin a channel to a tighter policy or
+  whitelist a false-positive sender. Defaults: alert-only for `low/medium`, auto-act on `high`.
+
+## 9. (Bonus, from #3) Route raw `git` through the policy gateway
+
+Today `git push` over HTTPS bypasses the integration gateway (only the GitHub MCP *tools* get
+`enforcePolicy` capability gates, `repoFilter` response filtering, rate limits, audit). Optional
+hardening: proxy git operations (or the agent's git credential helper) through the gateway so raw
+pushes inherit `canPush`/repo-allowlist/rate-limit/audit. Larger lift; tracked here, not phase 1.
+
+## 10. Data model (D1)
+
+```
+threat_events(
+  id, dashboard_id, session_id, kind,           -- 'egress_anomaly'|'inbound_injection'|'trifecta'
+  severity,                                      -- 'low'|'medium'|'high'
+  detail JSON,                                   -- signals, timeline, rationale
+  action_taken TEXT,                             -- 'alert'|'held'|'paused'|'tightened'
+  created_at, acknowledged_at, acknowledged_by
+)
+-- inbound_messages: + risk_score REAL, risk_category TEXT, risk_status TEXT
+-- egress_audit_log:  + bytes_out INTEGER, session_id (if not present)
+```
+Session risk state lives in a Durable Object (hot, rebuildable from the above), not a table.
+
+## 11. Phasing
+
+1. **Egress volume/rate anomaly (Phase 1)** — smallest, plumbing exists. Add `BytesOut` to
+   `AuditEvent`, sink classification in `defaults.json`, control-plane aggregation + threshold +
+   `threat_alert` toast + `threat_events` row. Alert-only first.
+2. **Inbound injection scanner (Phase 2)** — pre-filter + Haiku judge at the webhook chokepoint;
+   `inbound_messages.risk_*`; quarantine + UI flag + admin notify.
+3. **Trifecta correlation (Phase 3)** — session risk DO joining 1+2+sensitive-access; escalation
+   + auto-downgrade; correlated-timeline UI.
+4. **Admin dashboard + auto-adaptation polish (Phase 4)**.
+5. **(Optional) git-through-gateway (Phase 5)**.
+
+## 12. Security & privacy considerations
+- **Content scanning** reads message/email bodies in the control plane (where they already
+  transit). No new storage of raw secrets; store risk metadata, not full content beyond existing
+  `inbound_messages` retention. Document in privacy notes.
+- **Fail mode**: detection failing should *not* break delivery (fail-open for the scanner, with a
+  logged "scan unavailable" — unlike policy enforcement which is fail-closed). Anomaly auto-actions
+  must be reversible and rate-limited to avoid a DoS-on-self via false positives.
+- **Don't leak the detector**: keep thresholds/heuristics server-side; assume attackers probe.
+
+## 13. Open questions
+- Auto-act on `high` by default, or alert-only until an admin opts in per dashboard?
+- Haiku judge cost/latency budget per inbound message; cache identical content.
+- Where to draw the sink list (start static; later learn per-deployment baselines).
+- Trifecta window length and whether secret-broker use alone counts as "sensitive access".
+
+## 14. Honest bottom line
+This catches bulk/obvious exfil and naive/known injection, and — more importantly — gives the
+user and admin **observability and a control loop** the current "guardrails + YOLO" posture
+lacks. It does **not** close low-bandwidth side channels or stop a determined, adaptive attacker.
+The win is detection, notification, and shrinking blast radius — the bank-fraud-desk model, not a
+vault.

--- a/controlplane/src/db/schema.ts
+++ b/controlplane/src/db/schema.ts
@@ -146,6 +146,27 @@ CREATE TABLE IF NOT EXISTS user_subagents (
 
 CREATE INDEX IF NOT EXISTS idx_user_subagents_user ON user_subagents(user_id);
 
+-- User custom model endpoints (Ollama / vLLM / self-hosted / cloud BYO).
+-- See PLAN-custom-endpoints.md. The API key (if any) is a user_secrets entry
+-- referenced by secret_name; this table never stores the key.
+CREATE TABLE IF NOT EXISTS user_model_providers (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  label TEXT NOT NULL,
+  base_url TEXT NOT NULL,
+  format TEXT NOT NULL DEFAULT 'openai',            -- 'openai' | 'anthropic'
+  model_id TEXT NOT NULL,
+  secret_name TEXT,                                 -- ref to user_secrets.name (the API key), nullable
+  context_window INTEGER,
+  max_output_tokens INTEGER,
+  compatible_harnesses TEXT NOT NULL DEFAULT '[]',  -- JSON array of harness ids
+  is_local INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_model_providers_user ON user_model_providers(user_id);
+
 -- User agent skills (Claude Code slash command favorites)
 CREATE TABLE IF NOT EXISTS user_agent_skills (
   id TEXT PRIMARY KEY,

--- a/controlplane/src/index.ts
+++ b/controlplane/src/index.ts
@@ -26,6 +26,7 @@ import { nearestFlyRegion } from './sessions/handler';
 import * as recipes from './recipes/handler';
 import * as schedules from './schedules/handler';
 import * as subagents from './subagents/handler';
+import * as modelProviders from './model-providers/handler';
 import * as secrets from './secrets/handler';
 import * as agentSkills from './agent-skills/handler';
 import * as mcpTools from './mcp-tools/handler';
@@ -2095,6 +2096,28 @@ async function handleRequest(request: Request, env: EnvWithBindings, ctx: Pick<E
     const authError = requireAuth(auth);
     if (authError) return authError;
     return subagents.deleteSubagent(env, auth.user!.id, segments[1]);
+  }
+
+  // GET /model-providers - List saved custom model endpoints
+  if (segments[0] === 'model-providers' && segments.length === 1 && method === 'GET') {
+    const authError = requireAuth(auth);
+    if (authError) return authError;
+    return modelProviders.listModelProviders(env, auth.user!.id);
+  }
+
+  // POST /model-providers - Create custom model endpoint
+  if (segments[0] === 'model-providers' && segments.length === 1 && method === 'POST') {
+    const authError = requireAuth(auth);
+    if (authError) return authError;
+    const data = await request.json() as Record<string, unknown>;
+    return modelProviders.createModelProvider(env, auth.user!.id, data);
+  }
+
+  // DELETE /model-providers/:id - Delete custom model endpoint
+  if (segments[0] === 'model-providers' && segments.length === 2 && method === 'DELETE') {
+    const authError = requireAuth(auth);
+    if (authError) return authError;
+    return modelProviders.deleteModelProvider(env, auth.user!.id, segments[1]);
   }
 
   // DELETE /secrets/:id - Delete secret

--- a/controlplane/src/model-providers/handler.ts
+++ b/controlplane/src/model-providers/handler.ts
@@ -1,0 +1,118 @@
+// Copyright 2026 Rob Macrae. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-Proprietary
+//
+// CRUD for per-user custom model endpoints (Ollama / vLLM / self-hosted / cloud BYO).
+// See PLAN-custom-endpoints.md. The API key, if any, lives in user_secrets and is
+// referenced by secret_name — never stored here.
+
+import type { Env, UserModelProvider } from '../types';
+
+function safeJsonParse<T>(json: string | null | undefined, fallback: T): T {
+  if (!json) return fallback;
+  try {
+    return JSON.parse(json) as T;
+  } catch (error) {
+    console.error('[model-providers] bad JSON:', error, json?.substring(0, 100));
+    return fallback;
+  }
+}
+
+function formatProvider(row: Record<string, unknown>): UserModelProvider {
+  return {
+    id: row.id as string,
+    userId: row.user_id as string,
+    label: row.label as string,
+    baseUrl: row.base_url as string,
+    format: ((row.format as string) || 'openai') as 'openai' | 'anthropic',
+    modelId: row.model_id as string,
+    secretName: (row.secret_name as string) || undefined,
+    contextWindow: row.context_window == null ? undefined : Number(row.context_window),
+    maxOutputTokens: row.max_output_tokens == null ? undefined : Number(row.max_output_tokens),
+    compatibleHarnesses: safeJsonParse<string[]>((row.compatible_harnesses as string) || '[]', []),
+    isLocal: Number(row.is_local) === 1,
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+  };
+}
+
+/** Validate the base URL: http/https only, parseable. Returns the parsed URL or null. */
+function validateBaseUrl(raw: string): URL | null {
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
+    return u;
+  } catch {
+    return null;
+  }
+}
+
+export async function listModelProviders(env: Env, userId: string): Promise<Response> {
+  const rows = await env.DB.prepare(
+    `SELECT * FROM user_model_providers WHERE user_id = ? ORDER BY updated_at DESC`
+  )
+    .bind(userId)
+    .all();
+
+  return Response.json({
+    providers: rows.results.map((row) => formatProvider(row as Record<string, unknown>)),
+  });
+}
+
+export async function createModelProvider(
+  env: Env,
+  userId: string,
+  data: Partial<UserModelProvider>
+): Promise<Response> {
+  if (!data.label || !data.baseUrl || !data.modelId) {
+    return Response.json(
+      { error: 'E79901: label, baseUrl, and modelId are required' },
+      { status: 400 }
+    );
+  }
+  if (!validateBaseUrl(data.baseUrl)) {
+    return Response.json({ error: 'E79902: baseUrl must be a valid http(s) URL' }, { status: 400 });
+  }
+  const format = data.format === 'anthropic' ? 'anthropic' : 'openai';
+
+  const id = data.id || crypto.randomUUID();
+  await env.DB.prepare(
+    `INSERT INTO user_model_providers
+       (id, user_id, label, base_url, format, model_id, secret_name,
+        context_window, max_output_tokens, compatible_harnesses, is_local, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`
+  )
+    .bind(
+      id,
+      userId,
+      data.label,
+      data.baseUrl,
+      format,
+      data.modelId,
+      data.secretName || null,
+      data.contextWindow ?? null,
+      data.maxOutputTokens ?? null,
+      JSON.stringify(data.compatibleHarnesses || []),
+      data.isLocal ? 1 : 0
+    )
+    .run();
+
+  const row = await env.DB.prepare(`SELECT * FROM user_model_providers WHERE id = ?`)
+    .bind(id)
+    .first();
+
+  return Response.json({ provider: formatProvider(row as Record<string, unknown>) });
+}
+
+export async function deleteModelProvider(env: Env, userId: string, id: string): Promise<Response> {
+  const result = await env.DB.prepare(
+    `DELETE FROM user_model_providers WHERE id = ? AND user_id = ?`
+  )
+    .bind(id, userId)
+    .run();
+
+  if (result.meta.changes === 0) {
+    return Response.json({ error: 'E79903: Model provider not found' }, { status: 404 });
+  }
+
+  return new Response(null, { status: 204 });
+}

--- a/controlplane/src/sandbox/client.ts
+++ b/controlplane/src/sandbox/client.ts
@@ -226,10 +226,13 @@ export class SandboxClient {
       executionId?: string;
       // Per-terminal model selection (e.g. OpenRouter override) — sandbox injects per-harness env vars
       modelSelection?: {
-        provider: 'default' | 'openrouter';
+        provider: 'default' | 'openrouter' | 'custom';
         model?: string;
         contextWindow?: number;
         maxOutputTokens?: number;
+        baseUrl?: string;
+        format?: 'openai' | 'anthropic';
+        secretName?: string;
       };
     }
   ): Promise<SandboxPty> {

--- a/controlplane/src/sessions/handler.ts
+++ b/controlplane/src/sessions/handler.ts
@@ -94,11 +94,15 @@ export function nearestFlyRegion(cfContinent: string | undefined, warmPoolRegion
 }
 
 interface ModelSelection {
-  provider: 'default' | 'openrouter';
+  provider: 'default' | 'openrouter' | 'custom';
   model?: string;
   // Catalog-resolved limits, forwarded to the sandbox for Codex context flags.
   contextWindow?: number;
   maxOutputTokens?: number;
+  // Custom endpoint fields (provider === 'custom').
+  baseUrl?: string;
+  format?: 'openai' | 'anthropic';
+  secretName?: string;
 }
 
 interface TerminalContent {
@@ -200,16 +204,17 @@ function parseTerminalConfig(content: unknown): ParsedTerminalConfig {
       bootCommand = talkitoArgs.join(' ');
     }
 
+    const ms = parsed.modelSelection;
     const modelSelection: ModelSelection | undefined =
-      parsed.modelSelection &&
-      (parsed.modelSelection.provider === 'default' || parsed.modelSelection.provider === 'openrouter')
+      ms && (ms.provider === 'default' || ms.provider === 'openrouter' || ms.provider === 'custom')
         ? {
-            provider: parsed.modelSelection.provider,
-            model: typeof parsed.modelSelection.model === 'string' ? parsed.modelSelection.model : undefined,
-            contextWindow:
-              typeof parsed.modelSelection.contextWindow === 'number' ? parsed.modelSelection.contextWindow : undefined,
-            maxOutputTokens:
-              typeof parsed.modelSelection.maxOutputTokens === 'number' ? parsed.modelSelection.maxOutputTokens : undefined,
+            provider: ms.provider,
+            model: typeof ms.model === 'string' ? ms.model : undefined,
+            contextWindow: typeof ms.contextWindow === 'number' ? ms.contextWindow : undefined,
+            maxOutputTokens: typeof ms.maxOutputTokens === 'number' ? ms.maxOutputTokens : undefined,
+            baseUrl: typeof ms.baseUrl === 'string' ? ms.baseUrl : undefined,
+            format: ms.format === 'anthropic' ? 'anthropic' : ms.format === 'openai' ? 'openai' : undefined,
+            secretName: typeof ms.secretName === 'string' ? ms.secretName : undefined,
           }
         : undefined;
 

--- a/controlplane/src/types.ts
+++ b/controlplane/src/types.ts
@@ -206,6 +206,22 @@ export interface UserSubagent {
   updatedAt: string;
 }
 
+export interface UserModelProvider {
+  id: string;
+  userId: string;
+  label: string;
+  baseUrl: string;
+  format: 'openai' | 'anthropic';
+  modelId: string;
+  secretName?: string;
+  contextWindow?: number;
+  maxOutputTokens?: number;
+  compatibleHarnesses: string[];
+  isLocal: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface UserAgentSkill {
   id: string;
   userId: string;

--- a/frontend/src/components/blocks/TerminalBlock.tsx
+++ b/frontend/src/components/blocks/TerminalBlock.tsx
@@ -108,6 +108,10 @@ import {
   listMcpTools,
   type UserMcpTool,
   listSessionFiles,
+  listModelProviders,
+  createModelProvider,
+  deleteModelProvider,
+  type UserModelProvider,
 } from "@/lib/api/cloudflare";
 import type { Session } from "@/types/dashboard";
 import { useTerminalOverlay } from "@/components/terminal";
@@ -214,12 +218,17 @@ type McpToolCatalogCategory = {
 type ActivePanel = "secrets" | "subagents" | "agent-skills" | "mcp-tools" | "tts-voice" | "model" | "integrations" | "working-dir" | "tasks" | null;
 
 type ModelSelection = {
-  provider: "default" | "openrouter";
-  model?: string; // OpenRouter model id, only set when provider === "openrouter"
-  // Resolved from the catalog at selection time; forwarded to the sandbox so Codex
-  // gets correct -c model_context_window / model_max_output_tokens flags.
+  provider: "default" | "openrouter" | "custom";
+  model?: string; // OpenRouter model id (openrouter) or custom endpoint model id (custom)
+  // Resolved from the catalog/saved-provider at selection time; forwarded to the
+  // sandbox so Codex gets correct -c model_context_window / model_max_output_tokens.
   contextWindow?: number;
   maxOutputTokens?: number;
+  // Custom endpoint fields (provider === "custom"); see PLAN-custom-endpoints.md.
+  customProviderId?: string;
+  baseUrl?: string;
+  format?: "openai" | "anthropic";
+  secretName?: string;
 };
 
 type OpenRouterModel = {
@@ -924,6 +933,34 @@ export function TerminalBlock({
     },
   });
 
+  // Custom model endpoints (per-user saved providers)
+  const modelProvidersQuery = useQuery({
+    queryKey: ["model-providers"],
+    queryFn: () => listModelProviders(),
+    enabled: activePanel === "model",
+    staleTime: 60000,
+  });
+  const customProviders: UserModelProvider[] = modelProvidersQuery.data ?? [];
+
+  const createModelProviderMutation = useMutation({
+    mutationFn: createModelProvider,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["model-providers"] }),
+  });
+  const deleteModelProviderMutation = useMutation({
+    mutationFn: deleteModelProvider,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["model-providers"] }),
+  });
+
+  // Add-custom-endpoint form state
+  const [showCustomForm, setShowCustomForm] = React.useState(false);
+  const [cpLabel, setCpLabel] = React.useState("");
+  const [cpBaseUrl, setCpBaseUrl] = React.useState("");
+  const [cpModelId, setCpModelId] = React.useState("");
+  const [cpFormat, setCpFormat] = React.useState<"openai" | "anthropic">("openai");
+  const [cpApiKey, setCpApiKey] = React.useState("");
+  const [cpContextWindow, setCpContextWindow] = React.useState("");
+  const [cpMaxOutput, setCpMaxOutput] = React.useState("");
+
   // Agent Skills queries and mutations
   const agentSkillsQuery = useQuery({
     queryKey: ["agent-skills"],
@@ -1334,7 +1371,8 @@ export function TerminalBlock({
       const current = terminalMeta.modelSelection ?? { provider: "default" as const };
       const providerChanged = current.provider !== next.provider;
       const modelChanged = current.model !== next.model;
-      if (!providerChanged && !modelChanged) return;
+      const customChanged = current.customProviderId !== next.customProviderId;
+      if (!providerChanged && !modelChanged && !customChanged) return;
 
       // Resolve context/output limits from the catalog at selection time so the
       // sandbox can pass Codex correct -c model_context_window / max_output_tokens.
@@ -3426,6 +3464,194 @@ export function TerminalBlock({
                   {OPENROUTER_MODELS.filter((m) => m.compatibleHarnesses.includes(terminalType)).length === 0 && (
                     <div className="text-[10px] text-[var(--foreground-muted)] italic">
                       No OpenRouter models are compatible with this harness yet.
+                    </div>
+                  )}
+                </div>
+
+                {/* Custom endpoint section (Ollama / vLLM / self-hosted / BYO) */}
+                <div className="space-y-1.5 pt-2 border-t border-[var(--border)]">
+                  <div className="text-[10px] font-medium text-[var(--foreground-muted)] uppercase tracking-wide">
+                    Custom endpoint
+                  </div>
+                  {customProviders
+                    .filter((p) => p.compatibleHarnesses.length === 0 || p.compatibleHarnesses.includes(terminalType))
+                    .map((p) => {
+                      const selected =
+                        terminalMeta.modelSelection?.provider === "custom" &&
+                        terminalMeta.modelSelection?.customProviderId === p.id;
+                      return (
+                        <label
+                          key={p.id}
+                          className="flex items-start gap-2 px-2 py-1.5 rounded hover:bg-[var(--background)] cursor-pointer"
+                        >
+                          <input
+                            type="radio"
+                            name={`model-${id}`}
+                            checked={selected}
+                            onChange={() =>
+                              handleModelChange({
+                                provider: "custom",
+                                model: p.modelId,
+                                contextWindow: p.contextWindow,
+                                maxOutputTokens: p.maxOutputTokens,
+                                customProviderId: p.id,
+                                baseUrl: p.baseUrl,
+                                format: p.format,
+                                secretName: p.secretName,
+                              })
+                            }
+                            className="mt-0.5"
+                          />
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center justify-between gap-2">
+                              <div className="text-xs text-[var(--foreground)] truncate">{p.label}</div>
+                              <button
+                                type="button"
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  deleteModelProviderMutation.mutate(p.id);
+                                }}
+                                className="text-[10px] text-[var(--foreground-muted)] hover:text-[var(--status-error)] shrink-0"
+                                title="Remove endpoint"
+                              >
+                                <Trash2 className="w-3 h-3" />
+                              </button>
+                            </div>
+                            <div className="text-[10px] text-[var(--foreground-muted)] truncate">
+                              {p.format} · <code className="font-mono">{p.modelId}</code> · {p.baseUrl}
+                            </div>
+                          </div>
+                        </label>
+                      );
+                    })}
+
+                  {!showCustomForm ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setShowCustomForm(true)}
+                      className="h-6 text-[10px] text-[var(--accent-primary)]"
+                    >
+                      <Plus className="w-3 h-3 mr-1" />
+                      Add custom endpoint
+                    </Button>
+                  ) : (
+                    <div className="space-y-1.5 p-2 rounded border border-[var(--border)] bg-[var(--background)]">
+                      <input
+                        value={cpLabel}
+                        onChange={(e) => setCpLabel(e.target.value)}
+                        placeholder="Label (e.g. Local Ollama)"
+                        className="w-full px-2 py-1 text-[11px] rounded border border-[var(--border)] bg-[var(--background-elevated)] text-[var(--foreground)]"
+                      />
+                      <input
+                        value={cpBaseUrl}
+                        onChange={(e) => setCpBaseUrl(e.target.value)}
+                        placeholder="Base URL (e.g. http://localhost:11434/v1)"
+                        className="w-full px-2 py-1 text-[11px] rounded border border-[var(--border)] bg-[var(--background-elevated)] text-[var(--foreground)]"
+                      />
+                      <input
+                        value={cpModelId}
+                        onChange={(e) => setCpModelId(e.target.value)}
+                        placeholder="Model id (e.g. llama3.3:70b)"
+                        className="w-full px-2 py-1 text-[11px] rounded border border-[var(--border)] bg-[var(--background-elevated)] text-[var(--foreground)]"
+                      />
+                      <div className="flex gap-1.5">
+                        <select
+                          value={cpFormat}
+                          onChange={(e) => setCpFormat(e.target.value as "openai" | "anthropic")}
+                          className="px-2 py-1 text-[11px] rounded border border-[var(--border)] bg-[var(--background-elevated)] text-[var(--foreground)]"
+                        >
+                          <option value="openai">OpenAI-compatible</option>
+                          <option value="anthropic">Anthropic-compatible</option>
+                        </select>
+                        <input
+                          value={cpApiKey}
+                          onChange={(e) => setCpApiKey(e.target.value)}
+                          type="password"
+                          placeholder="API key (optional)"
+                          className="flex-1 min-w-0 px-2 py-1 text-[11px] rounded border border-[var(--border)] bg-[var(--background-elevated)] text-[var(--foreground)]"
+                        />
+                      </div>
+                      <div className="flex gap-1.5">
+                        <input
+                          value={cpContextWindow}
+                          onChange={(e) => setCpContextWindow(e.target.value)}
+                          placeholder="Context window"
+                          inputMode="numeric"
+                          className="flex-1 min-w-0 px-2 py-1 text-[11px] rounded border border-[var(--border)] bg-[var(--background-elevated)] text-[var(--foreground)]"
+                        />
+                        <input
+                          value={cpMaxOutput}
+                          onChange={(e) => setCpMaxOutput(e.target.value)}
+                          placeholder="Max output"
+                          inputMode="numeric"
+                          className="flex-1 min-w-0 px-2 py-1 text-[11px] rounded border border-[var(--border)] bg-[var(--background-elevated)] text-[var(--foreground)]"
+                        />
+                      </div>
+                      <div className="text-[10px] text-[var(--foreground-muted)] leading-snug">
+                        This endpoint receives the full conversation context — only add providers you trust.
+                      </div>
+                      <div className="flex items-center gap-1.5">
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          disabled={!cpLabel.trim() || !cpBaseUrl.trim() || !cpModelId.trim() || createModelProviderMutation.isPending}
+                          onClick={async () => {
+                            const cw = parseInt(cpContextWindow, 10);
+                            const mo = parseInt(cpMaxOutput, 10);
+                            // Store the raw key as a brokered secret (a valid env-var
+                            // name); the broker injects it server-side. The provider only
+                            // references the name, never the value.
+                            let secretName: string | undefined;
+                            const apiKey = cpApiKey.trim();
+                            if (apiKey) {
+                              secretName = `CUSTOM_KEY_${crypto.randomUUID().replace(/-/g, "").slice(0, 8).toUpperCase()}`;
+                              try {
+                                await createSecret({ dashboardId: "_global", name: secretName, value: apiKey });
+                              } catch (e) {
+                                console.error("[custom-endpoint] failed to store API key:", e);
+                                return;
+                              }
+                            }
+                            createModelProviderMutation.mutate(
+                              {
+                                label: cpLabel.trim(),
+                                baseUrl: cpBaseUrl.trim(),
+                                modelId: cpModelId.trim(),
+                                format: cpFormat,
+                                secretName,
+                                contextWindow: Number.isFinite(cw) ? cw : undefined,
+                                maxOutputTokens: Number.isFinite(mo) ? mo : undefined,
+                                compatibleHarnesses: ["claude", "codex", "opencode", "droid", "gemini"],
+                                isLocal: false,
+                              },
+                              {
+                                onSuccess: () => {
+                                  setShowCustomForm(false);
+                                  setCpLabel("");
+                                  setCpBaseUrl("");
+                                  setCpModelId("");
+                                  setCpApiKey("");
+                                  setCpContextWindow("");
+                                  setCpMaxOutput("");
+                                  setCpFormat("openai");
+                                },
+                              }
+                            );
+                          }}
+                          className="h-6 px-2 text-[10px]"
+                        >
+                          {createModelProviderMutation.isPending ? "Saving..." : "Save"}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setShowCustomForm(false)}
+                          className="h-6 px-2 text-[10px]"
+                        >
+                          Cancel
+                        </Button>
+                      </div>
                     </div>
                   )}
                 </div>

--- a/frontend/src/config/env.ts
+++ b/frontend/src/config/env.ts
@@ -135,6 +135,7 @@ export const API = {
     usersMe: `${CLOUDFLARE_API_URL}/users/me`,
     embedCheck: `${CLOUDFLARE_API_URL}/embed-check`,
     subagents: `${CLOUDFLARE_API_URL}/subagents`,
+    modelProviders: `${CLOUDFLARE_API_URL}/model-providers`,
     templates: `${CLOUDFLARE_API_URL}/templates`,
     secrets: `${CLOUDFLARE_API_URL}/secrets`,
     pendingApprovals: `${CLOUDFLARE_API_URL}/pending-approvals`,

--- a/frontend/src/lib/api/cloudflare/index.ts
+++ b/frontend/src/lib/api/cloudflare/index.ts
@@ -9,6 +9,7 @@ export * from "./dashboards";
 export * from "./users";
 export * from "./embed";
 export * from "./subagents";
+export * from "./model-providers";
 export * from "./attachments";
 export * from "./files";
 export * from "./secrets";

--- a/frontend/src/lib/api/cloudflare/model-providers.ts
+++ b/frontend/src/lib/api/cloudflare/model-providers.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 Rob Macrae. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-Proprietary
+//
+// Per-user custom model endpoints (Ollama / vLLM / self-hosted / cloud BYO).
+// See PLAN-custom-endpoints.md.
+
+import { API } from "@/config/env";
+import { apiGet, apiPost, apiDelete } from "../client";
+
+export interface UserModelProvider {
+  id: string;
+  label: string;
+  baseUrl: string;
+  format: "openai" | "anthropic";
+  modelId: string;
+  secretName?: string;
+  contextWindow?: number;
+  maxOutputTokens?: number;
+  compatibleHarnesses: string[];
+  isLocal: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ProvidersResponse {
+  providers: UserModelProvider[];
+}
+
+interface ProviderResponse {
+  provider: UserModelProvider;
+}
+
+export async function listModelProviders(): Promise<UserModelProvider[]> {
+  const response = await apiGet<ProvidersResponse>(API.cloudflare.modelProviders);
+  return response.providers || [];
+}
+
+export async function createModelProvider(data: {
+  label: string;
+  baseUrl: string;
+  format?: "openai" | "anthropic";
+  modelId: string;
+  secretName?: string;
+  contextWindow?: number;
+  maxOutputTokens?: number;
+  compatibleHarnesses?: string[];
+  isLocal?: boolean;
+}): Promise<UserModelProvider> {
+  const response = await apiPost<ProviderResponse>(API.cloudflare.modelProviders, data);
+  return response.provider;
+}
+
+export async function deleteModelProvider(id: string): Promise<void> {
+  await apiDelete<void>(`${API.cloudflare.modelProviders}/${id}`);
+}

--- a/sandbox/cmd/server/main.go
+++ b/sandbox/cmd/server/main.go
@@ -716,7 +716,10 @@ func (s *Server) handleCreatePTY(w http.ResponseWriter, r *http.Request) {
 			Model           string `json:"model"`
 			ContextWindow   int    `json:"contextWindow"`
 			MaxOutputTokens int    `json:"maxOutputTokens"`
-		} `json:"model_selection"` // Per-PTY OpenRouter override
+			BaseURL         string `json:"baseUrl"`
+			Format          string `json:"format"`
+			SecretName      string `json:"secretName"`
+		} `json:"model_selection"` // Per-PTY OpenRouter / custom-endpoint override
 	}
 	if r.Body != nil {
 		json.NewDecoder(r.Body).Decode(&req) // Ignore errors - all fields are optional
@@ -740,6 +743,9 @@ func (s *Server) handleCreatePTY(w http.ResponseWriter, r *http.Request) {
 				Model:           req.ModelSelection.Model,
 				ContextWindow:   req.ModelSelection.ContextWindow,
 				MaxOutputTokens: req.ModelSelection.MaxOutputTokens,
+				BaseURL:         req.ModelSelection.BaseURL,
+				Format:          req.ModelSelection.Format,
+				SecretName:      req.ModelSelection.SecretName,
 			}
 		}
 		ptyInfo, err = session.CreatePTYWithOptions(opts)

--- a/sandbox/internal/broker/provider_error_test.go
+++ b/sandbox/internal/broker/provider_error_test.go
@@ -54,3 +54,26 @@ func TestIsModelRoutingProvider(t *testing.T) {
 		}
 	}
 }
+
+func TestHostAllowed_DesktopCustomHTTP(t *testing.T) {
+	b := NewSecretsBroker(0)
+	// A custom endpoint reachable over http via the desktop VM host gateway.
+	b.SetConfig(ConfigKey("s1", "customprovider"), &ProviderConfig{
+		Name: "customprovider", TargetBaseURL: "http://10.0.2.2:11434/v1", SessionID: "s1",
+	})
+	key := ConfigKey("s1", "customprovider")
+	target := "http://10.0.2.2:11434/v1/chat/completions"
+
+	t.Setenv("ALLOW_HTTP_CUSTOM_ENDPOINT", "")
+	if b.hostAllowed(key, target) {
+		t.Errorf("http custom endpoint must be blocked without the desktop flag")
+	}
+	t.Setenv("ALLOW_HTTP_CUSTOM_ENDPOINT", "true")
+	if !b.hostAllowed(key, target) {
+		t.Errorf("http custom endpoint should be allowed with the desktop flag")
+	}
+	// Host-match still enforced: a different http host is rejected even with the flag.
+	if b.hostAllowed(key, "http://evil.example.com/v1/chat/completions") {
+		t.Errorf("host-match must still reject a non-configured http host")
+	}
+}

--- a/sandbox/internal/broker/secrets_broker.go
+++ b/sandbox/internal/broker/secrets_broker.go
@@ -156,6 +156,19 @@ func (b *SecretsBroker) GetAnthropicKey(sessionID string) string {
 	return ""
 }
 
+// GetCustomSecretValue returns the plaintext value of a brokered custom secret for
+// the session, or "" if not configured. Used to resolve the API key for a custom
+// model endpoint at PTY creation (PLAN-custom-endpoints.md).
+func (b *SecretsBroker) GetCustomSecretValue(sessionID, secretName string) string {
+	key := ConfigKey(sessionID, "custom/"+secretName)
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if config, exists := b.configs[key]; exists {
+		return config.SecretValue
+	}
+	return ""
+}
+
 // SetOnApprovalNeeded sets the callback for domain approval notifications.
 // The callback receives (sessionID, secretName, domain) so it knows which session to notify.
 func (b *SecretsBroker) SetOnApprovalNeeded(fn func(sessionID, secretName, domain string)) {
@@ -415,15 +428,18 @@ func (b *SecretsBroker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Inject auth header
-	authValue := fmt.Sprintf(headerFormat, secretValue)
-	outReq.Header.Set(headerName, authValue)
+	// Inject auth header. A custom-provider config with no key leaves headerName
+	// empty (no-auth endpoint) — skip injection rather than send an empty Bearer.
+	if headerName != "" {
+		outReq.Header.Set(headerName, fmt.Sprintf(headerFormat, secretValue))
+	}
 
 	// Always log the FIRST brokered call per (session, LLM-provider) — the
 	// zero-config way to confirm e.g. Claude Code is on `openrouter-anthropic`
 	// (OpenRouter) vs `anthropic` (native). Once-per-session so it isn't spammy.
 	// Only "agent" (LLM) providers; "tool" providers (TTS/ASR) are skipped.
-	if spec, ok := Providers[providerName]; ok && spec.Category == "agent" {
+	spec, isBuiltin := Providers[providerName]
+	if (isBuiltin && spec.Category == "agent") || providerName == "customprovider" {
 		if _, seen := b.loggedRoutes.LoadOrStore(sessionID+":"+providerName, true); !seen {
 			host := targetURL
 			if parsed, perr := url.Parse(targetURL); perr == nil {
@@ -530,6 +546,20 @@ func isLocalhostHTTPAllowed() bool {
 	return os.Getenv("DEV_MODE") == "true" || os.Getenv("ALLOW_HTTP_BROKER_LOCALHOST") == "true"
 }
 
+// allowHTTPCustomEndpoint reports whether http is allowed to a custom model endpoint.
+// Set by the desktop app, where a local model server (Ollama/LM Studio) is reached
+// over plain http via the VM's host gateway (e.g. http://10.0.2.2:11434). Never set
+// in the cloud, so cloud custom endpoints remain https-only.
+func allowHTTPCustomEndpoint() bool {
+	return os.Getenv("ALLOW_HTTP_CUSTOM_ENDPOINT") == "true"
+}
+
+// isCustomProviderConfigKey reports whether a broker config key is a custom model
+// endpoint (the session-scoped "customprovider" entry installed in session.go).
+func isCustomProviderConfigKey(providerID string) bool {
+	return strings.HasSuffix(providerID, ":customprovider")
+}
+
 // isLocalhost checks if a host is localhost
 func isLocalhost(host string) bool {
 	// Strip port if present
@@ -549,9 +579,14 @@ func (b *SecretsBroker) hostAllowed(providerID string, targetURL string) bool {
 		return false
 	}
 
-	// Check scheme: HTTPS required, except HTTP allowed for localhost in dev mode
+	// Check scheme: HTTPS required, except (a) HTTP for localhost in dev mode, and
+	// (b) HTTP to a custom model endpoint on desktop (local Ollama via the VM host
+	// gateway). The host-match check below still restricts (b) to the exact
+	// configured host, so this can't be used to reach an arbitrary http target.
 	if parsed.Scheme == "http" {
-		if !isLocalhost(parsed.Host) || !isLocalhostHTTPAllowed() {
+		localhostOK := isLocalhost(parsed.Host) && isLocalhostHTTPAllowed()
+		desktopCustomOK := isCustomProviderConfigKey(providerID) && allowHTTPCustomEndpoint()
+		if !localhostOK && !desktopCustomOK {
 			return false
 		}
 	} else if parsed.Scheme != "https" {

--- a/sandbox/internal/geminishim/anthropic.go
+++ b/sandbox/internal/geminishim/anthropic.go
@@ -1,0 +1,480 @@
+// Copyright 2026 Rob Macrae. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+// REVISION: model-gateway-v1-anthropic
+//
+// Anthropic Messages (Claude) ↔ OpenAI Chat Completions translation, sharing the
+// same broker-forwarding core (forwardChat) and OpenAI types as the Gemini path.
+// This is the second front-side format for the generalized model gateway
+// (PLAN-custom-endpoints.md): it lets Claude Code target any OpenAI-compatible
+// endpoint (OpenRouter today; custom/self-hosted next).
+//
+// Request URL shape (the harness's ANTHROPIC_BASE_URL points here; the SDK appends
+// /v1/messages):
+//
+//	http://127.0.0.1:<port>/av1/{sessionID}/{provider}/{base64url(model)}
+//
+// PROTOTYPE SCOPE: text + tool-calling, streaming and non-streaming. count_tokens
+// returns a char/4 estimate. The model id comes from the URL (the custom endpoint's
+// model), overriding whatever the harness put in the body.
+
+package geminishim
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// ---- Anthropic wire types (request subset) ----
+
+type anthReq struct {
+	Model         string          `json:"model"`
+	Messages      []anthMessage   `json:"messages"`
+	System        json.RawMessage `json:"system,omitempty"` // string | []{type:"text",text}
+	Tools         []anthTool      `json:"tools,omitempty"`
+	MaxTokens     int             `json:"max_tokens,omitempty"`
+	Temperature   *float64        `json:"temperature,omitempty"`
+	TopP          *float64        `json:"top_p,omitempty"`
+	StopSequences []string        `json:"stop_sequences,omitempty"`
+	Stream        bool            `json:"stream,omitempty"`
+}
+
+type anthMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"` // string | []anthBlock
+}
+
+type anthBlock struct {
+	Type string `json:"type"`
+	// text
+	Text string `json:"text,omitempty"`
+	// tool_use
+	ID    string         `json:"id,omitempty"`
+	Name  string         `json:"name,omitempty"`
+	Input map[string]any `json:"input,omitempty"`
+	// tool_result
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"` // string | []block
+}
+
+type anthTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"input_schema,omitempty"`
+}
+
+// ---- Anthropic wire types (non-streaming response) ----
+
+type anthResp struct {
+	ID         string         `json:"id"`
+	Type       string         `json:"type"` // "message"
+	Role       string         `json:"role"` // "assistant"
+	Model      string         `json:"model"`
+	Content    []anthOutBlock `json:"content"`
+	StopReason string         `json:"stop_reason"`
+	StopSeq    *string        `json:"stop_sequence"`
+	Usage      anthUsage      `json:"usage"`
+}
+
+type anthOutBlock struct {
+	Type  string         `json:"type"` // "text" | "tool_use"
+	Text  string         `json:"text,omitempty"`
+	ID    string         `json:"id,omitempty"`
+	Name  string         `json:"name,omitempty"`
+	Input map[string]any `json:"input,omitempty"`
+}
+
+type anthUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// parseAnthPath extracts sessionID, broker provider, and the decoded model from a
+// path of the form /av1/{sessionID}/{provider}/{modelB64}/v1/messages[...].
+func parseAnthPath(path string) (sessionID, provider, model string, ok bool) {
+	rest := strings.TrimPrefix(path, "/av1/")
+	if rest == path {
+		return "", "", "", false
+	}
+	parts := strings.SplitN(rest, "/", 4)
+	if len(parts) < 4 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", false
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil || len(decoded) == 0 {
+		return "", "", "", false
+	}
+	return parts[0], parts[1], string(decoded), true
+}
+
+// serveAnthropic handles an Anthropic Messages request: translate → forward via
+// broker → translate back.
+func (s *Shim) serveAnthropic(w http.ResponseWriter, r *http.Request) {
+	sessionID, provider, model, ok := parseAnthPath(r.URL.Path)
+	if !ok {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid path; expected /av1/{session}/{provider}/{model}/v1/messages")
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+
+	// count_tokens → estimate (no upstream support).
+	if strings.Contains(r.URL.Path, "count_tokens") {
+		handleAnthCountTokens(w, body)
+		return
+	}
+
+	var areq anthReq
+	if err := json.Unmarshal(body, &areq); err != nil {
+		writeAnthropicError(w, http.StatusBadRequest, "invalid Anthropic request: "+err.Error())
+		return
+	}
+
+	oreq := anthropicToOpenAI(areq, model)
+	oreqBody, err := json.Marshal(oreq)
+	if err != nil {
+		writeAnthropicError(w, http.StatusInternalServerError, "failed to encode upstream request")
+		return
+	}
+	log.Printf("[model-gateway] anthropic -> session=%s provider=%s model=%s stream=%t msgs=%d tools=%d",
+		sessionID, provider, model, areq.Stream, len(oreq.Messages), len(oreq.Tools))
+
+	resp, err := s.forwardChat(sessionID, provider, oreqBody)
+	if err != nil {
+		writeAnthropicError(w, http.StatusBadGateway, "broker request failed: "+err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(resp.Body)
+		log.Printf("[model-gateway] anthropic <- upstream HTTP %d session=%s body=%s", resp.StatusCode, sessionID, truncate(string(errBody), 2000))
+		writeAnthropicError(w, resp.StatusCode, "upstream error: "+strings.TrimSpace(string(errBody)))
+		return
+	}
+
+	if areq.Stream {
+		streamOpenAIToAnthropic(w, resp.Body, model)
+		return
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	var oresp oaiResp
+	if err := json.Unmarshal(respBody, &oresp); err != nil {
+		writeAnthropicError(w, http.StatusBadGateway, "failed to parse upstream response")
+		return
+	}
+	if oresp.Error != nil {
+		writeAnthropicError(w, http.StatusBadGateway, "upstream error: "+oresp.Error.String())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(openAIToAnthropic(oresp, model))
+}
+
+// anthropicToOpenAI converts an Anthropic Messages request to OpenAI Chat Completions.
+func anthropicToOpenAI(a anthReq, model string) oaiReq {
+	out := oaiReq{Model: model, Stream: a.Stream}
+
+	if sys := joinAnthSystem(a.System); sys != "" {
+		out.Messages = append(out.Messages, oaiMsg{Role: "system", Content: sys})
+	}
+
+	for _, m := range a.Messages {
+		blocks := parseAnthBlocks(m.Content)
+		text := joinAnthText(blocks)
+		switch m.Role {
+		case "assistant":
+			msg := oaiMsg{Role: "assistant", Content: text}
+			for _, b := range blocks {
+				if b.Type != "tool_use" {
+					continue
+				}
+				args, _ := json.Marshal(b.Input)
+				msg.ToolCalls = append(msg.ToolCalls, oaiToolCall{
+					ID:       b.ID,
+					Type:     "function",
+					Function: oaiFuncCall{Name: b.Name, Arguments: string(args)},
+				})
+			}
+			out.Messages = append(out.Messages, msg)
+		default: // "user"
+			var emittedToolResult bool
+			for _, b := range blocks {
+				if b.Type != "tool_result" {
+					continue
+				}
+				emittedToolResult = true
+				out.Messages = append(out.Messages, oaiMsg{
+					Role:       "tool",
+					ToolCallID: b.ToolUseID,
+					Content:    joinAnthText(parseAnthBlocks(b.Content)),
+				})
+			}
+			if text != "" || !emittedToolResult {
+				out.Messages = append(out.Messages, oaiMsg{Role: "user", Content: text})
+			}
+		}
+	}
+
+	for _, t := range a.Tools {
+		out.Tools = append(out.Tools, oaiTool{
+			Type: "function",
+			Function: oaiFuncDef{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  sanitizeSchema(t.InputSchema),
+			},
+		})
+	}
+
+	if a.MaxTokens > 0 {
+		mt := a.MaxTokens
+		out.MaxTokens = &mt
+	}
+	out.Temperature = a.Temperature
+	out.TopP = a.TopP
+	out.Stop = a.StopSequences
+	return out
+}
+
+// openAIToAnthropic converts a non-streaming OpenAI response to an Anthropic message.
+func openAIToAnthropic(o oaiResp, model string) anthResp {
+	out := anthResp{ID: "msg_orcabot", Type: "message", Role: "assistant", Model: model, StopReason: "end_turn"}
+	if len(o.Choices) == 0 {
+		out.Content = []anthOutBlock{{Type: "text", Text: ""}}
+		return out
+	}
+	choice := o.Choices[0]
+	if choice.Message.Content != "" {
+		out.Content = append(out.Content, anthOutBlock{Type: "text", Text: choice.Message.Content})
+	}
+	for _, tc := range choice.Message.ToolCalls {
+		input := map[string]any{}
+		if tc.Function.Arguments != "" {
+			_ = json.Unmarshal([]byte(tc.Function.Arguments), &input)
+		}
+		out.Content = append(out.Content, anthOutBlock{Type: "tool_use", ID: tc.ID, Name: tc.Function.Name, Input: input})
+	}
+	if len(out.Content) == 0 {
+		out.Content = []anthOutBlock{{Type: "text", Text: ""}}
+	}
+	out.StopReason = mapAnthStopReason(choice.FinishReason)
+	if o.Usage != nil {
+		out.Usage = anthUsage{InputTokens: o.Usage.PromptTokens, OutputTokens: o.Usage.CompletionTokens}
+	}
+	return out
+}
+
+// streamOpenAIToAnthropic reads an OpenAI SSE stream and re-emits it as the
+// Anthropic Messages event stream (message_start → content_block_* → message_delta
+// → message_stop). Text streams as it arrives; tool calls are accumulated and
+// emitted as tool_use blocks at the end.
+func streamOpenAIToAnthropic(w http.ResponseWriter, body io.Reader, model string) {
+	flusher, _ := w.(http.Flusher)
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+
+	emit := func(event string, payload any) {
+		data, _ := json.Marshal(payload)
+		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+
+	emit("message_start", map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id": "msg_orcabot", "type": "message", "role": "assistant", "model": model,
+			"content": []any{}, "stop_reason": nil, "stop_sequence": nil,
+			"usage": map[string]int{"input_tokens": 0, "output_tokens": 0},
+		},
+	})
+
+	reader := bufio.NewReader(body)
+	finishReason := "stop"
+	textOpen := false
+	toolAcc := map[int]*oaiToolCall{}
+	var usage *oaiUsage
+
+	for {
+		line, err := reader.ReadString('\n')
+		if t := strings.TrimSpace(line); strings.HasPrefix(t, "data:") {
+			payload := strings.TrimSpace(strings.TrimPrefix(t, "data:"))
+			if payload == "[DONE]" {
+				break
+			}
+			var chunk oaiStreamChunk
+			if json.Unmarshal([]byte(payload), &chunk) == nil && len(chunk.Choices) > 0 {
+				if chunk.Usage != nil {
+					usage = chunk.Usage
+				}
+				ch := chunk.Choices[0]
+				if ch.FinishReason != "" {
+					finishReason = ch.FinishReason
+				}
+				if ch.Delta.Content != "" {
+					if !textOpen {
+						emit("content_block_start", map[string]any{
+							"type": "content_block_start", "index": 0,
+							"content_block": map[string]any{"type": "text", "text": ""},
+						})
+						textOpen = true
+					}
+					emit("content_block_delta", map[string]any{
+						"type": "content_block_delta", "index": 0,
+						"delta": map[string]any{"type": "text_delta", "text": ch.Delta.Content},
+					})
+				}
+				for _, tc := range ch.Delta.ToolCalls {
+					acc := toolAcc[tc.Index]
+					if acc == nil {
+						acc = &oaiToolCall{}
+						toolAcc[tc.Index] = acc
+					}
+					if tc.ID != "" {
+						acc.ID = tc.ID
+					}
+					if tc.Function.Name != "" {
+						acc.Function.Name = tc.Function.Name
+					}
+					acc.Function.Arguments += tc.Function.Arguments
+				}
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	if textOpen {
+		emit("content_block_stop", map[string]any{"type": "content_block_stop", "index": 0})
+	}
+	// Emit accumulated tool calls as tool_use blocks (indices after the text block).
+	idx := 1
+	for _, tc := range sortedToolCalls(toolAcc) {
+		emit("content_block_start", map[string]any{
+			"type": "content_block_start", "index": idx,
+			"content_block": map[string]any{"type": "tool_use", "id": tc.ID, "name": tc.Function.Name, "input": map[string]any{}},
+		})
+		emit("content_block_delta", map[string]any{
+			"type": "content_block_delta", "index": idx,
+			"delta": map[string]any{"type": "input_json_delta", "partial_json": tc.Function.Arguments},
+		})
+		emit("content_block_stop", map[string]any{"type": "content_block_stop", "index": idx})
+		idx++
+	}
+
+	outTokens := 0
+	if usage != nil {
+		outTokens = usage.CompletionTokens
+	}
+	emit("message_delta", map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": mapAnthStopReason(finishReason), "stop_sequence": nil},
+		"usage": map[string]int{"output_tokens": outTokens},
+	})
+	emit("message_stop", map[string]any{"type": "message_stop"})
+}
+
+func handleAnthCountTokens(w http.ResponseWriter, body []byte) {
+	var areq anthReq
+	_ = json.Unmarshal(body, &areq)
+	chars := len(joinAnthSystem(areq.System))
+	for _, m := range areq.Messages {
+		chars += len(joinAnthText(parseAnthBlocks(m.Content)))
+	}
+	est := chars / 4
+	if est < 1 && chars > 0 {
+		est = 1
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]int{"input_tokens": est})
+}
+
+// ---- helpers ----
+
+func parseAnthBlocks(raw json.RawMessage) []anthBlock {
+	if len(raw) == 0 {
+		return nil
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return []anthBlock{{Type: "text", Text: s}}
+	}
+	var blocks []anthBlock
+	_ = json.Unmarshal(raw, &blocks)
+	return blocks
+}
+
+func joinAnthText(blocks []anthBlock) string {
+	var b strings.Builder
+	for _, blk := range blocks {
+		if blk.Type == "text" && blk.Text != "" {
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(blk.Text)
+		}
+	}
+	return b.String()
+}
+
+// joinAnthSystem handles the system field, which is a string or an array of text blocks.
+func joinAnthSystem(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	return joinAnthText(parseAnthBlocks(raw))
+}
+
+// sortedToolCalls returns accumulated streaming tool calls ordered by index.
+func sortedToolCalls(acc map[int]*oaiToolCall) []oaiToolCall {
+	idxs := make([]int, 0, len(acc))
+	for i := range acc {
+		idxs = append(idxs, i)
+	}
+	sort.Ints(idxs)
+	out := make([]oaiToolCall, 0, len(idxs))
+	for _, i := range idxs {
+		out = append(out, *acc[i])
+	}
+	return out
+}
+
+func mapAnthStopReason(r string) string {
+	switch r {
+	case "length":
+		return "max_tokens"
+	case "tool_calls", "function_call":
+		return "tool_use"
+	case "stop", "":
+		return "end_turn"
+	default:
+		return "end_turn"
+	}
+}
+
+func writeAnthropicError(w http.ResponseWriter, code int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"type":  "error",
+		"error": map[string]any{"type": "api_error", "message": message},
+	})
+}

--- a/sandbox/internal/geminishim/anthropic_test.go
+++ b/sandbox/internal/geminishim/anthropic_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Rob Macrae. All rights reserved.
+// SPDX-License-Identifier: LicenseRef-Proprietary
+
+package geminishim
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseAnthPath(t *testing.T) {
+	b64 := base64.RawURLEncoding.EncodeToString([]byte("anthropic/claude-sonnet-4.6"))
+	path := "/av1/sess1/openrouter/" + b64 + "/v1/messages"
+	sid, prov, model, ok := parseAnthPath(path)
+	if !ok || sid != "sess1" || prov != "openrouter" || model != "anthropic/claude-sonnet-4.6" {
+		t.Fatalf("parseAnthPath = %q %q %q ok=%v", sid, prov, model, ok)
+	}
+}
+
+func TestAnthropicToOpenAI_SystemTextTools(t *testing.T) {
+	a := anthReq{
+		System:   json.RawMessage(`"be terse"`),
+		Messages: []anthMessage{{Role: "user", Content: json.RawMessage(`"hello"`)}},
+		Tools: []anthTool{{
+			Name: "get_weather", Description: "weather",
+			InputSchema: map[string]any{"type": "OBJECT", "properties": map[string]any{"city": map[string]any{"type": "STRING"}}},
+		}},
+		MaxTokens: 256,
+	}
+	o := anthropicToOpenAI(a, "x/y")
+	if o.Model != "x/y" {
+		t.Errorf("model = %q", o.Model)
+	}
+	if len(o.Messages) != 2 || o.Messages[0].Role != "system" || o.Messages[1].Role != "user" {
+		t.Fatalf("messages = %+v", o.Messages)
+	}
+	if o.Messages[0].Content != "be terse" || o.Messages[1].Content != "hello" {
+		t.Errorf("content mapping wrong: %+v", o.Messages)
+	}
+	if len(o.Tools) != 1 || o.Tools[0].Function.Name != "get_weather" {
+		t.Errorf("tools = %+v", o.Tools)
+	}
+	// Schema types must be lowercased (sanitizeSchema reused).
+	props := o.Tools[0].Function.Parameters["properties"].(map[string]any)
+	if props["city"].(map[string]any)["type"] != "string" {
+		t.Errorf("schema not sanitized: %+v", o.Tools[0].Function.Parameters)
+	}
+	if o.MaxTokens == nil || *o.MaxTokens != 256 {
+		t.Errorf("max_tokens not mapped: %+v", o.MaxTokens)
+	}
+}
+
+func TestAnthropicToOpenAI_ToolRoundTrip(t *testing.T) {
+	a := anthReq{Messages: []anthMessage{
+		{Role: "assistant", Content: json.RawMessage(`[{"type":"tool_use","id":"call_1","name":"get_weather","input":{"city":"SF"}}]`)},
+		{Role: "user", Content: json.RawMessage(`[{"type":"tool_result","tool_use_id":"call_1","content":"sunny"}]`)},
+	}}
+	o := anthropicToOpenAI(a, "x/y")
+	// assistant tool_call then a tool message with the matching id.
+	if len(o.Messages) != 2 {
+		t.Fatalf("messages = %+v", o.Messages)
+	}
+	if o.Messages[0].Role != "assistant" || len(o.Messages[0].ToolCalls) != 1 || o.Messages[0].ToolCalls[0].ID != "call_1" {
+		t.Errorf("assistant tool_call wrong: %+v", o.Messages[0])
+	}
+	if o.Messages[1].Role != "tool" || o.Messages[1].ToolCallID != "call_1" || o.Messages[1].Content != "sunny" {
+		t.Errorf("tool result wrong: %+v", o.Messages[1])
+	}
+}
+
+func TestOpenAIToAnthropic_TextAndUsage(t *testing.T) {
+	var o oaiResp
+	_ = json.Unmarshal([]byte(`{"choices":[{"message":{"content":"hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}`), &o)
+	a := openAIToAnthropic(o, "x/y")
+	if a.Type != "message" || a.Role != "assistant" || a.Model != "x/y" {
+		t.Errorf("envelope wrong: %+v", a)
+	}
+	if len(a.Content) != 1 || a.Content[0].Type != "text" || a.Content[0].Text != "hi" {
+		t.Errorf("content wrong: %+v", a.Content)
+	}
+	if a.StopReason != "end_turn" || a.Usage.InputTokens != 3 || a.Usage.OutputTokens != 2 {
+		t.Errorf("stop/usage wrong: %+v", a)
+	}
+}
+
+func TestServeAnthropic_NonStreaming(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/broker/sid/openrouter/chat/completions") {
+			t.Errorf("bad broker path: %s", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"content":"hello there"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2}}`)
+	}))
+	defer broker.Close()
+
+	rec := callAnth(New(0, brokerPortFromURL(t, broker.URL)), "x/y", `{"model":"ignored","messages":[{"role":"user","content":"hi"}]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var a anthResp
+	if err := json.Unmarshal(rec.Body.Bytes(), &a); err != nil {
+		t.Fatalf("bad anthropic json: %v (%s)", err, rec.Body.String())
+	}
+	if a.Content[0].Text != "hello there" || a.StopReason != "end_turn" {
+		t.Errorf("translated response wrong: %+v", a)
+	}
+}
+
+func TestServeAnthropic_Streaming(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fl, _ := w.(http.Flusher)
+		for _, c := range []string{
+			`{"choices":[{"delta":{"content":"Hel"}}]}`,
+			`{"choices":[{"delta":{"content":"lo"}}]}`,
+			`{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}`,
+		} {
+			_, _ = io.WriteString(w, "data: "+c+"\n\n")
+			if fl != nil {
+				fl.Flush()
+			}
+		}
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer broker.Close()
+
+	rec := callAnth(New(0, brokerPortFromURL(t, broker.URL)), "x/y", `{"stream":true,"messages":[{"role":"user","content":"hi"}]}`)
+	body := rec.Body.String()
+	for _, want := range []string{
+		"event: message_start",
+		"text_delta",
+		`"text":"Hel"`,
+		`"text":"lo"`,
+		"event: message_delta",
+		"event: message_stop",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("stream missing %q\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "[DONE]") {
+		t.Errorf("must not forward [DONE]: %s", body)
+	}
+}
+
+func callAnth(s *Shim, model, body string) *httptest.ResponseRecorder {
+	b64 := base64.RawURLEncoding.EncodeToString([]byte(model))
+	req := httptest.NewRequest(http.MethodPost, "/av1/sid/openrouter/"+b64+"/v1/messages", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	s.ServeHTTP(rec, req)
+	return rec
+}

--- a/sandbox/internal/geminishim/shim.go
+++ b/sandbox/internal/geminishim/shim.go
@@ -98,11 +98,17 @@ func (s *Shim) Stop() error {
 	return s.server.Close()
 }
 
-// ServeHTTP routes a Gemini-format request to the OpenRouter translation.
+// ServeHTTP routes a harness-format request to the chat-completions translation.
+// Gemini requests use the `/gv1/` prefix; Anthropic (Claude) requests use `/av1/`.
 func (s *Shim) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	sessionID, model, method, ok := parsePath(r.URL.Path)
+	if strings.HasPrefix(r.URL.Path, "/av1/") {
+		s.serveAnthropic(w, r)
+		return
+	}
+
+	sessionID, provider, model, method, ok := parsePath(r.URL.Path)
 	if !ok {
-		writeGeminiError(w, http.StatusBadRequest, "invalid shim path; expected /gv1/{session}/{model}/v1.../models/{m}:{method}")
+		writeGeminiError(w, http.StatusBadRequest, "invalid shim path; expected /gv1/{session}/{provider}/{model}/v1.../models/{m}:{method}")
 		return
 	}
 
@@ -114,9 +120,9 @@ func (s *Shim) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch method {
 	case "generateContent":
-		s.handleGenerate(w, sessionID, model, body, false)
+		s.handleGenerate(w, sessionID, provider, model, body, false)
 	case "streamGenerateContent":
-		s.handleGenerate(w, sessionID, model, body, true)
+		s.handleGenerate(w, sessionID, provider, model, body, true)
 	case "countTokens":
 		handleCountTokens(w, body)
 	case "embedContent", "batchEmbedContents":
@@ -126,30 +132,31 @@ func (s *Shim) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// parsePath extracts sessionID, the decoded OpenRouter model, and the RPC method
-// from a shim request path of the form:
+// parsePath extracts sessionID, the broker provider, the decoded model, and the
+// RPC method from a shim request path of the form:
 //
-//	/gv1/{sessionID}/{modelB64}/{apiVersion}/models/{cliModel}:{method}
-func parsePath(path string) (sessionID, model, method string, ok bool) {
+//	/gv1/{sessionID}/{provider}/{modelB64}/{apiVersion}/models/{cliModel}:{method}
+func parsePath(path string) (sessionID, provider, model, method string, ok bool) {
 	rest := strings.TrimPrefix(path, "/gv1/")
 	if rest == path {
-		return "", "", "", false
+		return "", "", "", "", false
 	}
-	parts := strings.SplitN(rest, "/", 3)
-	if len(parts) < 3 || parts[0] == "" || parts[1] == "" {
-		return "", "", "", false
+	parts := strings.SplitN(rest, "/", 4)
+	if len(parts) < 4 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", "", false
 	}
 	sessionID = parts[0]
-	decoded, err := base64.RawURLEncoding.DecodeString(parts[1])
+	provider = parts[1]
+	decoded, err := base64.RawURLEncoding.DecodeString(parts[2])
 	if err != nil || len(decoded) == 0 {
-		return "", "", "", false
+		return "", "", "", "", false
 	}
 	model = string(decoded)
 
 	// The method is the segment after the final ':'.
 	colon := strings.LastIndex(path, ":")
 	if colon == -1 {
-		return "", "", "", false
+		return "", "", "", "", false
 	}
 	method = path[colon+1:]
 	// Drop any trailing query that LastIndex(path) wouldn't (URL.Path has no query),
@@ -157,12 +164,31 @@ func parsePath(path string) (sessionID, model, method string, ok bool) {
 	if slash := strings.IndexByte(method, '/'); slash != -1 {
 		method = method[:slash]
 	}
-	return sessionID, model, method, method != ""
+	return sessionID, provider, model, method, method != ""
+}
+
+// forwardChat sends an already-translated OpenAI Chat Completions request through
+// the broker for the given provider (e.g. "openrouter", or a custom-provider ref)
+// and returns the response for the caller to translate. The broker injects the
+// real key; the placeholder Authorization satisfies any client-side key guard.
+//
+// Parameterizing the provider is the foundation for custom/self-hosted endpoints
+// (PLAN-custom-endpoints.md): the same translation core forwards to OpenRouter or
+// to a user-configured custom-provider broker entry.
+func (s *Shim) forwardChat(sessionID, provider string, oreqBody []byte) (*http.Response, error) {
+	url := fmt.Sprintf("http://127.0.0.1:%d/broker/%s/%s/chat/completions", s.brokerPort, sessionID, provider)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(oreqBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer broker-injected")
+	return s.client.Do(req)
 }
 
 // handleGenerate translates a Gemini generate request to OpenAI Chat Completions,
 // forwards it through the broker, and translates the response back.
-func (s *Shim) handleGenerate(w http.ResponseWriter, sessionID, model string, body []byte, stream bool) {
+func (s *Shim) handleGenerate(w http.ResponseWriter, sessionID, provider, model string, body []byte, stream bool) {
 	var greq genReq
 	if err := json.Unmarshal(body, &greq); err != nil {
 		writeGeminiError(w, http.StatusBadRequest, "invalid Gemini request: "+err.Error())
@@ -182,20 +208,9 @@ func (s *Shim) handleGenerate(w http.ResponseWriter, sessionID, model string, bo
 		log.Printf("[gemini-shim] openai request: %s", truncate(string(oreqBody), 4000))
 	}
 
-	brokerURL := fmt.Sprintf("http://127.0.0.1:%d/broker/%s/openrouter/chat/completions", s.brokerPort, sessionID)
-	upReq, err := http.NewRequest(http.MethodPost, brokerURL, bytes.NewReader(oreqBody))
+	resp, err := s.forwardChat(sessionID, provider, oreqBody)
 	if err != nil {
-		writeGeminiError(w, http.StatusInternalServerError, "failed to build upstream request")
-		return
-	}
-	upReq.Header.Set("Content-Type", "application/json")
-	// The broker strips this and injects the real bearer token; send a placeholder
-	// so any client-side "needs a key" guard upstream is satisfied.
-	upReq.Header.Set("Authorization", "Bearer broker-injected")
-
-	resp, err := s.client.Do(upReq)
-	if err != nil {
-		writeGeminiError(w, http.StatusBadGateway, "broker/openrouter request failed: "+err.Error())
+		writeGeminiError(w, http.StatusBadGateway, "broker request failed: "+err.Error())
 		return
 	}
 	defer resp.Body.Close()

--- a/sandbox/internal/geminishim/shim_test.go
+++ b/sandbox/internal/geminishim/shim_test.go
@@ -17,14 +17,17 @@ import (
 func TestParsePath(t *testing.T) {
 	model := "deepseek/deepseek-chat"
 	b64 := base64.RawURLEncoding.EncodeToString([]byte(model))
-	path := "/gv1/sess123/" + b64 + "/v1beta/models/gemini-2.5-pro:streamGenerateContent"
+	path := "/gv1/sess123/openrouter/" + b64 + "/v1beta/models/gemini-2.5-pro:streamGenerateContent"
 
-	sid, gotModel, method, ok := parsePath(path)
+	sid, provider, gotModel, method, ok := parsePath(path)
 	if !ok {
 		t.Fatalf("parsePath failed for %q", path)
 	}
 	if sid != "sess123" {
 		t.Errorf("sid = %q, want sess123", sid)
+	}
+	if provider != "openrouter" {
+		t.Errorf("provider = %q, want openrouter", provider)
 	}
 	if gotModel != model {
 		t.Errorf("model = %q, want %q", gotModel, model)
@@ -210,7 +213,7 @@ func brokerPortFromURL(t *testing.T, raw string) int {
 
 func callShim(s *Shim, model, method, body string) *httptest.ResponseRecorder {
 	b64 := base64.RawURLEncoding.EncodeToString([]byte(model))
-	path := "/gv1/sid/" + b64 + "/v1beta/models/gemini-x:" + method
+	path := "/gv1/sid/openrouter/" + b64 + "/v1beta/models/gemini-x:" + method
 	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	s.ServeHTTP(rec, req)

--- a/sandbox/internal/sessions/model_selection.go
+++ b/sandbox/internal/sessions/model_selection.go
@@ -9,6 +9,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -25,15 +27,25 @@ func init() {
 
 // ModelSelection describes a per-PTY override for the model/provider the harness should use.
 // provider="default" means the harness uses its built-in API. provider="openrouter" routes
-// requests through the local broker to OpenRouter.
+// requests through the local broker to OpenRouter. provider="custom" routes through the local
+// broker to a user-configured OpenAI-compatible endpoint (PLAN-custom-endpoints.md).
 type ModelSelection struct {
-	Provider string // "default" | "openrouter"
-	Model    string // OpenRouter model id, e.g. "anthropic/claude-sonnet-4.6"
+	Provider string // "default" | "openrouter" | "custom"
+	Model    string // OpenRouter / custom-endpoint model id
 	// Catalog-resolved limits (0 = unknown). Used to set Codex's
 	// model_context_window / model_max_output_tokens so it doesn't fall back to
 	// wrong defaults for models it doesn't recognize.
 	ContextWindow   int
 	MaxOutputTokens int
+	// Custom endpoint fields (Provider == "custom").
+	BaseURL    string // user endpoint base URL, e.g. https://my-llm.example.com/v1
+	Format     string // "openai" | "anthropic" (front-side the harness speaks)
+	SecretName string // name of the brokered secret holding the API key (empty = no auth)
+}
+
+// IsCustom returns true if the selection routes to a user-configured custom endpoint.
+func (m *ModelSelection) IsCustom() bool {
+	return m != nil && m.Provider == "custom" && m.Model != "" && m.BaseURL != ""
 }
 
 // IsOpenRouter returns true if the selection requests routing through OpenRouter.
@@ -104,7 +116,7 @@ func applyOpenRouterEnv(envVars map[string]string, agentType mcp.AgentType, sel 
 			return
 		}
 		modelB64 := base64.RawURLEncoding.EncodeToString([]byte(sel.Model))
-		shimURL := fmt.Sprintf("http://127.0.0.1:%d/gv1/%s/%s", geminiShimPort, sessionID, modelB64)
+		shimURL := fmt.Sprintf("http://127.0.0.1:%d/gv1/%s/openrouter/%s", geminiShimPort, sessionID, modelB64)
 		envVars["GOOGLE_GEMINI_BASE_URL"] = shimURL
 		// GATEWAY mode reads GEMINI_API_KEY; a placeholder is enough — the broker
 		// injects the real OpenRouter key downstream of the shim.
@@ -113,6 +125,81 @@ func applyOpenRouterEnv(envVars map[string]string, agentType mcp.AgentType, sel 
 	default:
 		log.Printf("[model-selection] agent=%s OpenRouter routing not supported", agentType)
 	}
+}
+
+// customProviderName is the broker provider key for a session's custom endpoint.
+// The broker config (target URL + key) is installed in session.go; the broker's
+// built-in forwarding path handles /broker/{sid}/customprovider/... generically.
+const customProviderName = "customprovider"
+
+// applyCustomEndpointEnv wires a harness to a user-configured custom endpoint via
+// the broker's customprovider config. OpenAI-native harnesses point straight at the
+// broker; Claude goes through the gateway's /av1 Anthropic→chat translator. Codex
+// (Responses→chat) and Gemini custom routing are not wired yet.
+func applyCustomEndpointEnv(envVars map[string]string, agentType mcp.AgentType, sel *ModelSelection, sessionID string, brokerPort, geminiShimPort int) {
+	if !sel.IsCustom() {
+		return
+	}
+	brokerURL := fmt.Sprintf("http://localhost:%d/broker/%s/%s", brokerPort, sessionID, customProviderName)
+	switch agentType {
+	case mcp.AgentTypeOpenCode, mcp.AgentTypeDroid:
+		envVars["OPENAI_BASE_URL"] = brokerURL
+		envVars["OPENAI_MODEL"] = sel.Model
+		envVars["OPENAI_API_KEY"] = broker.GetDummyValue("openai")
+		log.Printf("[model-selection] agent=%s routing via custom endpoint model=%s broker=%s", agentType, sel.Model, brokerURL)
+	case mcp.AgentTypeClaude:
+		modelB64 := base64.RawURLEncoding.EncodeToString([]byte(sel.Model))
+		shimURL := fmt.Sprintf("http://127.0.0.1:%d/av1/%s/%s/%s", geminiShimPort, sessionID, customProviderName, modelB64)
+		envVars["ANTHROPIC_BASE_URL"] = shimURL
+		// Valid-looking placeholder so Claude enters API mode; the broker injects
+		// the real key (if any). See [[claude-openrouter-auth-friction]].
+		envVars["ANTHROPIC_API_KEY"] = "sk-ant-api03-orcabot-custom-endpoint-placeholder"
+		log.Printf("[model-selection] agent=claude routing via custom endpoint model=%s url=%s", sel.Model, shimURL)
+	case mcp.AgentTypeGemini:
+		modelB64 := base64.RawURLEncoding.EncodeToString([]byte(sel.Model))
+		shimURL := fmt.Sprintf("http://127.0.0.1:%d/gv1/%s/%s/%s", geminiShimPort, sessionID, customProviderName, modelB64)
+		envVars["GOOGLE_GEMINI_BASE_URL"] = shimURL
+		// GATEWAY auth flag (security.auth.selectedType/useExternal) is written in
+		// session.go for both OpenRouter and custom Gemini selections.
+		envVars["GEMINI_API_KEY"] = broker.GetDummyValue("gemini")
+		log.Printf("[model-selection] agent=gemini routing via custom endpoint model=%s url=%s", sel.Model, shimURL)
+	default:
+		log.Printf("[model-selection] agent=%s custom endpoint routing not supported yet", agentType)
+	}
+}
+
+// hostGatewayAddr is the address the sandbox VM uses to reach the host (for desktop
+// local model servers). QEMU user-net / slirp maps the host to 10.0.2.2; overridable.
+func hostGatewayAddr() string {
+	if g := os.Getenv("ORCABOT_HOST_GATEWAY"); g != "" {
+		return g
+	}
+	return "10.0.2.2"
+}
+
+// rewriteCustomBaseURLForDesktop rewrites a localhost custom-endpoint URL to the VM
+// host gateway so the sandbox can reach a model server (Ollama/LM Studio) running on
+// the host. Desktop-only — gated on ALLOW_HTTP_CUSTOM_ENDPOINT; no-op otherwise, so
+// cloud endpoints (real public hosts) are untouched.
+func rewriteCustomBaseURLForDesktop(baseURL string) string {
+	if os.Getenv("ALLOW_HTTP_CUSTOM_ENDPOINT") != "true" {
+		return baseURL
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return baseURL
+	}
+	switch u.Hostname() {
+	case "localhost", "127.0.0.1", "::1":
+		gw := hostGatewayAddr()
+		if port := u.Port(); port != "" {
+			u.Host = gw + ":" + port
+		} else {
+			u.Host = gw
+		}
+		return u.String()
+	}
+	return baseURL
 }
 
 // shellSingleQuote wraps s as a single safe POSIX shell token.

--- a/sandbox/internal/sessions/model_selection_test.go
+++ b/sandbox/internal/sessions/model_selection_test.go
@@ -3,6 +3,8 @@ package sessions
 import (
 	"strings"
 	"testing"
+
+	"github.com/Hyper-Int/OrcaBot/sandbox/internal/mcp"
 )
 
 func TestBuildCodexOpenRouterCommand(t *testing.T) {
@@ -31,6 +33,44 @@ func TestBuildCodexOpenRouterCommand(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("rewritten command missing %q\n  full: %s", want, got)
 		}
+	}
+}
+
+func TestApplyCustomEndpointEnv_OpenAINative(t *testing.T) {
+	sel := &ModelSelection{Provider: "custom", Model: "llama3.3:70b", BaseURL: "https://my-llm.example.com/v1", Format: "openai"}
+	for _, agent := range []mcp.AgentType{mcp.AgentTypeOpenCode, mcp.AgentTypeDroid} {
+		env := map[string]string{}
+		applyCustomEndpointEnv(env, agent, sel, "sess1", 8082, 8086)
+		if env["OPENAI_BASE_URL"] != "http://localhost:8082/broker/sess1/customprovider" {
+			t.Errorf("%s OPENAI_BASE_URL = %q", agent, env["OPENAI_BASE_URL"])
+		}
+		if env["OPENAI_MODEL"] != "llama3.3:70b" {
+			t.Errorf("%s OPENAI_MODEL = %q", agent, env["OPENAI_MODEL"])
+		}
+		if env["OPENAI_API_KEY"] == "" {
+			t.Errorf("%s should set a placeholder OPENAI_API_KEY", agent)
+		}
+	}
+}
+
+func TestApplyCustomEndpointEnv_Claude(t *testing.T) {
+	sel := &ModelSelection{Provider: "custom", Model: "llama3.3:70b", BaseURL: "https://x/v1", Format: "openai"}
+	env := map[string]string{}
+	applyCustomEndpointEnv(env, mcp.AgentTypeClaude, sel, "sess1", 8082, 8086)
+	// ANTHROPIC_BASE_URL points at the gateway /av1 with the customprovider ref.
+	if !strings.Contains(env["ANTHROPIC_BASE_URL"], "/av1/sess1/customprovider/") {
+		t.Errorf("ANTHROPIC_BASE_URL = %q", env["ANTHROPIC_BASE_URL"])
+	}
+	if !strings.HasPrefix(env["ANTHROPIC_API_KEY"], "sk-ant-") {
+		t.Errorf("ANTHROPIC_API_KEY should be a valid-looking placeholder: %q", env["ANTHROPIC_API_KEY"])
+	}
+}
+
+func TestApplyCustomEndpointEnv_NoopWhenNotCustom(t *testing.T) {
+	env := map[string]string{}
+	applyCustomEndpointEnv(env, mcp.AgentTypeOpenCode, &ModelSelection{Provider: "openrouter", Model: "x"}, "s", 8082, 8086)
+	if len(env) != 0 {
+		t.Errorf("non-custom selection should be a no-op, got %v", env)
 	}
 }
 
@@ -65,5 +105,27 @@ func TestBuildCodexOpenRouterCommand_NoopWhenDefault(t *testing.T) {
 	}
 	if got := buildCodexOpenRouterCommand("codex", nil, "s", 8082); got != "codex" {
 		t.Errorf("nil selection should be a no-op, got %q", got)
+	}
+}
+
+func TestRewriteCustomBaseURLForDesktop(t *testing.T) {
+	t.Setenv("ALLOW_HTTP_CUSTOM_ENDPOINT", "")
+	if got := rewriteCustomBaseURLForDesktop("http://localhost:11434/v1"); got != "http://localhost:11434/v1" {
+		t.Errorf("no flag = no-op, got %q", got)
+	}
+	t.Setenv("ALLOW_HTTP_CUSTOM_ENDPOINT", "true")
+	if got := rewriteCustomBaseURLForDesktop("http://localhost:11434/v1"); got != "http://10.0.2.2:11434/v1" {
+		t.Errorf("localhost should rewrite to host gateway, got %q", got)
+	}
+	if got := rewriteCustomBaseURLForDesktop("http://127.0.0.1:1234/v1"); got != "http://10.0.2.2:1234/v1" {
+		t.Errorf("127.0.0.1 should rewrite, got %q", got)
+	}
+	// A real public host is left alone even with the flag.
+	if got := rewriteCustomBaseURLForDesktop("https://my-llm.example.com/v1"); got != "https://my-llm.example.com/v1" {
+		t.Errorf("public host must be untouched, got %q", got)
+	}
+	t.Setenv("ORCABOT_HOST_GATEWAY", "192.168.64.1")
+	if got := rewriteCustomBaseURLForDesktop("http://localhost:11434/v1"); got != "http://192.168.64.1:11434/v1" {
+		t.Errorf("custom gateway override not honored, got %q", got)
 	}
 }

--- a/sandbox/internal/sessions/session.go
+++ b/sandbox/internal/sessions/session.go
@@ -703,6 +703,30 @@ func (s *Session) CreatePTYWithOptions(opts CreatePTYOptions) (*PTYInfo, error) 
 	// REVISION: model-selection-v1-openrouter
 	applyOpenRouterEnv(envVars, agentType, modelSelection, s.ID, s.BrokerPort(), s.GeminiShimPort())
 
+	// Custom endpoint (Ollama / vLLM / self-hosted / cloud BYO): install a broker
+	// customprovider config pointing at the user URL (with the brokered key, if any),
+	// then wire the harness env. The broker's built-in forwarding handles the rest.
+	// REVISION: model-selection-v6-custom-endpoint
+	if modelSelection.IsCustom() {
+		key := ""
+		if modelSelection.SecretName != "" {
+			key = s.broker.GetCustomSecretValue(s.ID, modelSelection.SecretName)
+		}
+		headerName, headerFormat := "", ""
+		if key != "" {
+			headerName, headerFormat = "Authorization", "Bearer %s"
+		}
+		s.broker.SetConfig(broker.ConfigKey(s.ID, customProviderName), &broker.ProviderConfig{
+			Name:          customProviderName,
+			TargetBaseURL: rewriteCustomBaseURLForDesktop(modelSelection.BaseURL),
+			HeaderName:    headerName,
+			HeaderFormat:  headerFormat,
+			SecretValue:   key,
+			SessionID:     s.ID,
+		})
+		applyCustomEndpointEnv(envVars, agentType, modelSelection, s.ID, s.BrokerPort(), s.GeminiShimPort())
+	}
+
 	// Per-PTY config directory: non-pool mode only. Same rationale as CreatePTY.
 	// REVISION: session-v22-pool-empty-mcp-env
 	if pty.GetPool() == nil {
@@ -775,18 +799,28 @@ func (s *Session) CreatePTYWithOptions(opts CreatePTYOptions) (*PTYInfo, error) 
 		//   Default + ANTHROPIC_API_KEY brokered → standard apiKeyHelper flow.
 		//   Default + no brokered Anthropic key → nothing to do.
 		if agentType == mcp.AgentTypeClaude {
-			if modelSelection.IsOpenRouter() {
+			switch {
+			case modelSelection.IsOpenRouter():
 				if err := agenthooks.SetClaudeModelForOpenRouter(s.workspace.Root(), modelSelection.Model); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to set Claude OpenRouter model: %v\n", err)
 				}
-			} else {
+			case modelSelection.IsCustom():
+				// Custom endpoint via the /av1 shim: the shim takes the model from the
+				// URL, so don't write a model id. Pass "" to strip any leftover
+				// apiKeyHelper so the placeholder key + shim ANTHROPIC_BASE_URL stand.
+				if err := agenthooks.SetClaudeModelForOpenRouter(s.workspace.Root(), ""); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to clear Claude apiKeyHelper for custom: %v\n", err)
+				}
+			default:
 				// Default provider — wipe any leftover OpenRouter model id so the
 				// native Anthropic endpoint doesn't see provider-prefixed ids.
 				if err := agenthooks.ClearClaudeOpenRouterModel(s.workspace.Root()); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to clear OpenRouter model: %v\n", err)
 				}
 			}
-			if !modelSelection.IsOpenRouter() && s.broker.GetAnthropicKey(s.ID) != "" {
+			// apiKeyHelper is for NATIVE Claude only — not OpenRouter, not custom
+			// (both inject auth at the broker URL boundary).
+			if !modelSelection.IsOpenRouter() && !modelSelection.IsCustom() && s.broker.GetAnthropicKey(s.ID) != "" {
 				if pty.GetPool() != nil {
 					if err := agenthooks.SetClaudeApiKeyHelperUnixSocket(s.workspace.Root()); err != nil {
 						fmt.Fprintf(os.Stderr, "Warning: failed to set Claude apiKeyHelper (unix-socket): %v\n", err)
@@ -812,11 +846,12 @@ func (s *Session) CreatePTYWithOptions(opts CreatePTYOptions) (*PTYInfo, error) 
 		if agentType == mcp.AgentTypeGemini {
 			envVars["GEMINI_CLI_SYSTEM_SETTINGS_PATH"] = filepath.Join(s.workspace.Root(), ".orcabot", "gemini-system-settings.json")
 
-			// OpenRouter routing relies on the CLI's GATEWAY auth honoring the
-			// shim URL in GOOGLE_GEMINI_BASE_URL. Set the gateway auth fields when
-			// OpenRouter is selected; clear them otherwise so native auth returns.
+			// OpenRouter / custom routing relies on the CLI's GATEWAY auth honoring
+			// the shim URL in GOOGLE_GEMINI_BASE_URL. Set the gateway auth fields when
+			// OpenRouter or a custom endpoint is selected; clear them otherwise so
+			// native auth returns.
 			// REVISION: gemini-shim-v1-openrouter-bridge
-			if modelSelection.IsOpenRouter() {
+			if modelSelection.IsOpenRouter() || modelSelection.IsCustom() {
 				if err := agenthooks.SetGeminiOpenRouterAuth(s.workspace.Root()); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to set Gemini OpenRouter auth: %v\n", err)
 				}


### PR DESCRIPTION
Custom model endpoints (Ollama / vLLM / self-hosted / cloud BYO):
- "Custom endpoint" option in the per-terminal Model panel: per-user saved providers (user_model_providers) with label/base URL/format/model/limits; raw API key auto-stored as a brokered secret (never in the provider record).
- Routes any harness to an OpenAI-compatible endpoint through the broker: OpenCode/Droid direct (OPENAI_BASE_URL), Claude via the /av1 Anthropic→chat shim, Gemini via the /gv1 shim (now provider-parameterized). Codex (Responses →chat) is the remaining harness.
- Broker reuses its built-in forwarding for /broker/{sid}/customprovider (target from config + SSRF host-match); GetCustomSecretValue resolves the key; no-auth guard skips the header for keyless local servers.
- Desktop: http-allowance gated on ALLOW_HTTP_CUSTOM_ENDPOINT (SSRF host-match preserved) + localhost→VM host-gateway (10.0.2.2) rewrite, so a local Ollama is reachable. Tauri auto-detect UX still TODO (needs desktop env).

Generalized geminishim into a model gateway: forwardChat(provider) parameterizes the broker target; added Anthropic Messages↔OpenAI chat translation (anthropic.go, streaming + tools); /gv1 path carries the provider.

OpenRouter routing fixes: Codex wire_api="responses" via -c flags + per-model context/output limits; broker provider-error toasts (429/402/etc); IS_SANDBOX=1 for Claude --dangerously-skip-permissions as root + fast-fail restart guard; Claude valid-looking ANTHROPIC_API_KEY placeholder; custom-Claude apiKeyHelper fix.

Plans: PLAN-custom-endpoints.md, PLAN-threat-detection.md.