### PR TITLE
chore: hide "Switch to CLI" button; stop release.sh double-building

### DIFF
--- a/desktop/scripts/release.sh
+++ b/desktop/scripts/release.sh
@@ -71,15 +71,14 @@ fi
 VERSION=$(read_version)
 echo "== target release: v$VERSION"
 
-# --- 3. Build bundled resources (frontend + workerd; bakes OAuth) ---------
-echo "== building desktop resources (frontend + control-plane workerd)..."
-sh "$SCRIPT_DIR/build-desktop-resources.sh"
-
-# --- 4. Signed + notarized app build --------------------------------------
-echo "== cargo tauri build (signed + notarized; this takes a while)..."
+# --- 3. Signed + notarized app build --------------------------------------
+# cargo tauri build's beforeBuildCommand (tauri.conf.json) already runs
+# build-desktop-resources.sh (frontend + control-plane workerd; bakes OAuth),
+# so we do NOT invoke it here — doing both rebuilt everything twice.
+echo "== cargo tauri build (builds resources via beforeBuildCommand, then signs + notarizes; this takes a while)..."
 ( cd "$SRC_TAURI" && cargo tauri build )
 
-# --- 5. Preflight gate + publish ------------------------------------------
+# --- 4. Preflight gate + publish ------------------------------------------
 echo "== publishing v$VERSION..."
 sh "$SCRIPT_DIR/publish-release.sh"
 

--- a/frontend/src/app/(app)/dashboards/page.tsx
+++ b/frontend/src/app/(app)/dashboards/page.tsx
@@ -28,7 +28,6 @@ import {
   XCircle,
   Clock,
   BarChart3,
-  Terminal,
   LogIn,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -55,7 +54,6 @@ import { TrialBanner } from "@/components/subscription/TrialBanner";
 import { DesktopVersionBadge } from "@/components/DesktopVersionBadge";
 import { DashboardsTabs } from "@/components/desktop/DashboardsTabs";
 import { API, DESKTOP_MODE } from "@/config/env";
-import { switchToCli } from "@/lib/tauri-bridge";
 import {
   listDashboards,
   createDashboard,
@@ -420,28 +418,7 @@ export default function DashboardsPage() {
             <Tooltip content="Toggle theme">
               <ThemeToggle />
             </Tooltip>
-            {DESKTOP_MODE && (
-              <Tooltip content="Switch to CLI (opens a terminal)">
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={async () => {
-                    try {
-                      const ok = await switchToCli();
-                      if (ok) {
-                        toast.success("Opening the CLI in Terminal…");
-                      } else {
-                        toast.error("CLI switch unavailable (Tauri bridge not found)");
-                      }
-                    } catch (e) {
-                      toast.error(`Could not switch to CLI: ${e}`);
-                    }
-                  }}
-                >
-                  <Terminal className="w-4 h-4" />
-                </Button>
-              </Tooltip>
-            )}
+            {/* "Switch to CLI" button removed until surface-switching ships. */}
             <Tooltip content="Settings">
               <Button variant="ghost" size="icon-sm" onClick={() => router.push("/settings")}>
                 <Settings className="w-4 h-4" />


### PR DESCRIPTION
- Remove the desktop-only "Switch to CLI" dashboard-header button (and its now-unused switchToCli/Terminal imports) — surface switching isn't released yet, so the button shouldn't be exposed.
- release.sh no longer calls build-desktop-resources.sh explicitly: cargo tauri build's beforeBuildCommand already runs it, so the previous flow rebuilt the frontend + workerd bundles twice.