### PR TITLE
chore(desktop): bump version to 0.9.2

### DIFF
--- a/desktop/app/src-tauri/Cargo.lock
+++ b/desktop/app/src-tauri/Cargo.lock
@@ -2555,7 +2555,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orcabot-desktop"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ctrlc",
  "filetime",

--- a/desktop/app/src-tauri/Cargo.toml
+++ b/desktop/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orcabot-desktop"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 description = "Orcabot Desktop shell"
 license = "UNLICENSED"

--- a/desktop/app/src-tauri/tauri.conf.json
+++ b/desktop/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Orcabot",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "identifier": "com.orcabot.desktop",
   "build": {
     "beforeDevCommand": "sh -c \"cd ../../frontend && NEXT_PUBLIC_API_URL=http://localhost:8787 NEXT_PUBLIC_SITE_URL=http://localhost:8788 NEXT_PUBLIC_DEV_MODE_ENABLED=true NEXT_PUBLIC_DESKTOP_MODE=true npx wrangler dev -c wrangler.toml --port 8788\"",


### PR DESCRIPTION
0.9.2 payload since 0.9.1:
- controlplane: bug-hunt round 2 (recipe IDOR, input-validation 500s, egress race, DO-orphan, Stripe/Telegram/invite races) + curated starter templates
- frontend: desktop OAuth connect-button fixes
- desktop CLI: orcabot import path-safety hardening
- sandbox: bug-hunt round 2 leak/race fixes — these live in the VM image, so a new VM image (v4) must be published for them to reach users.